### PR TITLE
Add use-expect rule

### DIFF
--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -1,0 +1,124 @@
+# Ensure that `expect` is called (require-expect)
+
+QUnit's `assert.expect(...)` helps developers create tests that correctly fail
+when their expected number of assertions are not called. QUnit will throw an
+error if no assertions are called by the time the test ends unless a developer
+also calls `assert.expect(0)`. QUnit also has a [configuration
+option](https://api.qunitjs.com/QUnit.config/) to require `expect` for every
+test.
+
+This rule checks for `expect` at linting time. The default "always" option
+requires that `expect` is called in each test. The "except-simple" option only
+requires an `expect` call when an assertion is called inside of a block or when
+`assert` is passed to another function. The rationale here is that by wrapping
+`assert` statements in conditional blocks or callbacks, developers are at risk
+of creating tests that incorrectly pass by skipping assertions.
+
+# Rule Details
+
+When using the default "always" option, each test needs an expect call. So this
+example is not valid.
+
+```js
+test('name', function(assert) {
+    assert.ok(true);
+});
+```
+
+This example would not warn.
+
+```js
+test('name', function(assert) {
+    assert.expect(1);
+    assert.ok(true);
+});
+
+test('name', function() {
+    expect(1);
+    ok(true);
+});
+```
+
+When using the "except-simple" option, the following patterns are considered
+warnings.
+
+```js
+test('name', function(assert) {
+    if (someCondition) {
+        assert.ok(true);
+    }
+});
+
+test('name', function(assert) {
+    maybeCallback(function() {
+        assert.ok(true);
+    });
+});
+
+test('name', function(assert) {
+    var callback = function() {
+        assert.ok(true);
+    }
+    callback();
+});
+
+test('name', function(assert) {
+    maybeCallback(function() {
+        assert.expect(2); // Must be called in the main test function.
+        assert.ok(true);
+    });
+});
+
+test('name', function(assert) {
+    myCustomAssertionWrapper(assert);
+});
+```
+
+The following patterns are not considered warnings when using the
+"except-simple" option.
+
+```js
+test('name', function(assert) {
+    assert.ok(true);
+});
+
+test('name', function() {
+    ok(true);
+});
+
+test('name', function(assert) {
+    assert.expect(2);
+
+    if (true) {
+        assert.ok(true);
+        callMeBack(function() {
+            assert.ok(true);
+        });
+    }
+});
+
+test('name', function() {
+    expect(0);
+
+    if (failureCondition) {
+        ok(false);
+    }
+});
+
+test('name', function(assert) {
+    assert.expect(1);
+    myCustomAssertionWrapper(assert);
+});
+```
+
+# When Not to Use It
+
+1. If your tests have some logic that relies on an unpredictable number of
+   assertions being called.
+
+2. If you are confident with your assertion logic and don't want the overhead of
+   calling `expect`.
+
+## Further Reading
+
+* [QUnit's Assertions](https://api.qunitjs.com/category/assert/)

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
         "no-global-assertions": require("./lib/rules/no-global-assertions"),
         "no-ok-equality": require("./lib/rules/no-ok-equality"),
         "no-only": require("./lib/rules/no-only"),
-        "resolve-async": require("./lib/rules/resolve-async")
+        "resolve-async": require("./lib/rules/resolve-async"),
+        "require-expect": require("./lib/rules/require-expect")
     },
     rulesConfig: {
         "assert-args": 1,
@@ -21,6 +22,7 @@ module.exports = {
         "no-global-assertions": 0,
         "no-ok-equality": 1,
         "no-only": 1,
-        "resolve-async": 2
+        "resolve-async": 2,
+        "require-expect": 0
     }
 };

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview Require the use of `expect` when using `assert` inside of a
+ * block or when passing `assert` to a function.
+ * @author Mitch Lloyd
+ */
+"use strict";
+
+var utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function (context) {
+    var EXCEPT_SIMPLE_ERROR_MESSAGE = "Should use `{{assertPrefix}}expect()` when using assertions outside of the top-level test callback",
+        ALWAYS_ERROR_MESSAGE = "Test is missing `{{assertPrefix}}expect()` call`",
+        currentTest = false;
+
+    function isGlobalExpectCall(callee) {
+        return callee.type === "Identifier" && callee.name === "expect";
+    }
+
+    function isAssertExpectCall(callee) {
+        return callee.object &&
+               callee.object.type === "Identifier" &&
+               callee.object.name === currentTest.assertName &&
+               callee.property.name === "expect";
+    }
+
+    function isExpectCall(callee) {
+        return isGlobalExpectCall(callee) || isAssertExpectCall(callee);
+    }
+
+    function isTopLevelExpectCall(callee) {
+        return isExpectCall(callee) && currentTest.blockDepth === 1;
+    }
+
+    function isUsingAssertInNestedBlock(node) {
+        return currentTest.blockDepth > 1 && utils.isAssertion(node.callee, currentTest.assertName);
+    }
+
+    function isPassingAssertAsArgument(node) {
+        if (!currentTest.assertName) {
+            return false;
+        }
+
+        for (var i = 0; i < node.arguments.length; i++) {
+            if (node.arguments[i].name === currentTest.assertName) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function isViolatingExceptSimpleRule(node) {
+        return !currentTest.isExpectUsed &&
+               (isUsingAssertInNestedBlock(node) || isPassingAssertAsArgument(node));
+    }
+
+    function captureTestContext(node) {
+        currentTest = {
+            assertName: utils.getAssertContextNameForTest(node.arguments),
+            node: node,
+            blockDepth: 0,
+            isExpectUsed: false
+        };
+    }
+
+    function releaseTestContext() {
+        currentTest = false;
+    }
+
+    function assertionMessageData() {
+        var prefix;
+
+        if (currentTest.assertName) {
+            prefix = currentTest.assertName + ".";
+        } else {
+            prefix = "";
+        }
+
+        return { assertPrefix: prefix };
+    }
+
+    var ExceptSimpleStrategy = {
+        "CallExpression": function (node) {
+            if (currentTest) {
+                if (isTopLevelExpectCall(node.callee)) {
+                    currentTest.isExpectUsed = true;
+                } else if (isViolatingExceptSimpleRule(node)) {
+                    context.report({
+                        node: currentTest.node,
+                        message: EXCEPT_SIMPLE_ERROR_MESSAGE,
+                        data: assertionMessageData()
+                    });
+                }
+            } else if (utils.isTest(node.callee)) {
+                captureTestContext(node);
+            }
+        },
+
+        "CallExpression:exit": function (node) {
+            if (utils.isTest(node.callee)) {
+                releaseTestContext();
+            }
+        },
+
+        "BlockStatement": function () {
+            if (currentTest) {
+                currentTest.blockDepth++;
+            }
+        },
+
+        "BlockStatement:exit": function () {
+            if (currentTest) {
+                currentTest.blockDepth--;
+            }
+        }
+    };
+
+    var AlwaysStrategy = {
+        "CallExpression": function (node) {
+            if (currentTest && isExpectCall(node.callee)) {
+                currentTest.isExpectUsed = true;
+            } else if (utils.isTest(node.callee)) {
+                captureTestContext(node);
+            }
+        },
+
+        "CallExpression:exit": function (node) {
+            if (utils.isTest(node.callee)) {
+                if (!currentTest.isExpectUsed) {
+                    context.report({
+                        node: currentTest.node,
+                        message: ALWAYS_ERROR_MESSAGE,
+                        data: assertionMessageData()
+                    });
+                }
+
+                releaseTestContext();
+            }
+        }
+    };
+
+    return context.options[0] === "except-simple" ? ExceptSimpleStrategy : AlwaysStrategy;
+};
+
+module.exports.schema = [
+    {
+        "enum": ["except-simple", "always"]
+    }
+];

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -1,0 +1,300 @@
+/**
+ * @fileoverview Require the use of `expect` when using `assert` inside of a
+ * block or when passing `assert` to a function.
+ * @author Mitch Lloyd
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/require-expect"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester(),
+    returnAndIndent = "\n        ";
+
+function alwaysErrorMessage(expectCallName) {
+    return "Test is missing `" + expectCallName + "()` call`";
+}
+
+function exceptSimpleErrorMessage(expectCallName) {
+    return "Should use `" + expectCallName + "()` when using assertions outside of the top-level test callback";
+}
+
+ruleTester.run("require-expect", rule, {
+
+    valid: [
+        // default, calling expect is valid
+        {
+            code: "test('name', function(assert) { assert.expect(0) });",
+            options: []
+        },
+
+        // default, using global expect
+        {
+            code: "test('name', function() { expect(0) });",
+            options: []
+        },
+
+        // CallExpression without parent object throws no errors
+        {
+            code: "test('name', function(assert) { assert.expect(0); noParentObject() });",
+            options: []
+        },
+
+        // assert at top of test context is ok
+        {
+            code: "test('name', function(assert) { assert.ok(true) });",
+            options: ["except-simple"]
+        },
+
+        // global assertion at top of test context is ok
+        {
+            code: "test('name', function() { ok(true) });",
+            options: ["except-simple"]
+        },
+
+        // assert in block with expect at the top of test context is ok
+        {
+            code: "test('name', function(assert) { assert.expect(0); if (false) { assert.ok(false) } });",
+            options: ["except-simple"]
+        },
+
+        // global assertion in block with expect at the top of test context is ok
+        {
+            code: "test('name', function() { expect(0); if (false) { ok(false) } });",
+            options: ["except-simple"]
+        },
+
+        // nested modules
+        {
+            code: [
+                "module('a', function() {",
+                "    test('a - test', function(assert) {",
+                "        assert.ok(true, 'no expect needed');",
+                "    });",
+                "",
+                "    module('b', function() {",
+                "        test('b - test', function() {",
+                "            ok(true, 'still no expect needed');",
+                "        });",
+                "    });",
+                "});"
+            ].join(returnAndIndent),
+            options: ["except-simple"]
+        }
+
+    ],
+
+    invalid: [
+        // default - make sure expect is identified correctly
+        {
+            code: "test('name', function(assert) { other.assert.expect(0) });",
+            errors: [{
+                message: alwaysErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: []
+        },
+
+        // assert in loop block
+        {
+            code: "test('name', function(assert) { while (false) { assert.ok(true) } });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // global assertion in loop block
+        {
+            code: "test('name', function() { for (;;) { ok(true) } });",
+            errors: [{
+                message: exceptSimpleErrorMessage("expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // assert used in callback
+        {
+            code: "test('name', function(assert) { maybe(function() { assert.ok(true) }); });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // global assertion used in callback
+        {
+            code: "test('name', function(assert) { maybe(function() { ok(true) }); });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // assert in function expression
+        {
+            code: "test('name', function(assert) { var maybe = function() { assert.ok(true) }; });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // global assertion in function expression
+        {
+            code: "test('name', function() { var maybe = function() { ok(true) }; });",
+            errors: [{
+                message: exceptSimpleErrorMessage("expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // `expect` does not count when used inside of a block.
+        {
+            code: "test('name', function(assert) { function name() { assert.expect(1); assert.ok(true) } });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // global `expect` does not count when used inside of a block.
+        {
+            code: "test('name', function() { function name() { expect(1); ok(true) } });",
+            errors: [{
+                message: exceptSimpleErrorMessage("expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // `expect` does not count when used inside of a callback
+        {
+            code: "test('name', function(assert) { maybe(function() { assert.expect(1); assert.ok(true) }); });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // global `expect` does not count when used inside of a callback
+        {
+            code: "test('name', function() { maybe(function() { expect(1); ok(true) }); });",
+            errors: [{
+                message: exceptSimpleErrorMessage("expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // assert in outer test context and nested in a block
+        {
+            code: "test('name', function(assert) { assert.ok(true); if (true) { assert.ok(true); } });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // Deeply nested
+        {
+            code: "test('name', function() { if (true) { if (true) { ok(true); } } });",
+            errors: [{
+                message: exceptSimpleErrorMessage("expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // Sending assert to a function
+        {
+            code: [
+                "function myAssertion(a, assert, c) { assert.ok(true); }",
+                "test('name', function(assert) { myAssertion(null, assert, null); });"
+            ].join(returnAndIndent),
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // Sending assert to a function - renaming assert
+        {
+            code: [
+                "function myAssertion(a, localAssert, c) { localAssert.ok(true); }",
+                "test('name', function(myAssert) { myAssertion(null, myAssert, null); });"
+            ].join(returnAndIndent),
+            errors: [{
+                message: exceptSimpleErrorMessage("myAssert.expect"),
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
+        // nested modules
+        {
+            code: [
+                "module('a', function() {",
+                "    test('a - test', function(assert) {",
+                "        if (false) {",
+                "            assert.ok(true, 'needs expect');",
+                "        }",
+                "    });",
+                "",
+                "    module('b', function() {",
+                "        test('b - test', function(assert) {",
+                "            assert.expect(1);",
+                "            assert.ok(true, 'has expect');",
+                "        });",
+                "    });",
+                "});"
+            ].join(returnAndIndent),
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                type: "CallExpression",
+                line: 2
+            }],
+            options: ["except-simple"]
+        },
+
+        // "always" configration - simple case
+        {
+            code: "test('name', function(assert) { assert.ok(true) })",
+            options: [],
+            errors: [{ message: alwaysErrorMessage("assert.expect") }]
+        },
+
+        // "always" configration - global assertion
+        {
+            code: "test('name', function() { equal(1, 1) })",
+            options: [],
+            errors: [{ message: alwaysErrorMessage("expect") }]
+        },
+
+        // "always" configuration checking that "expect" is called on assert.
+        {
+            code: "test('name', function(assert) { other.expect(1); assert.ok(true); });",
+            options: [],
+            errors: [{ message: alwaysErrorMessage("assert.expect") }]
+        }
+    ]
+
+});


### PR DESCRIPTION
I've been working on a rule that advises when `assert.expect(n)` should be used in a test. The goal is to avoid issues where developers write assertions that are mistakenly never called.  Do you think this would make a good addition to this project?