### PR TITLE
require-expect using "except-simple" config should only report one error per test

### DIFF
--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -62,7 +62,8 @@ module.exports = function (context) {
             assertName: utils.getAssertContextNameForTest(node.arguments),
             node: node,
             blockDepth: 0,
-            isExpectUsed: false
+            isExpectUsed: false,
+            didReport: false
         };
     }
 
@@ -84,7 +85,7 @@ module.exports = function (context) {
 
     var ExceptSimpleStrategy = {
         "CallExpression": function (node) {
-            if (currentTest) {
+            if (currentTest && !currentTest.didReport) {
                 if (isTopLevelExpectCall(node.callee)) {
                     currentTest.isExpectUsed = true;
                 } else if (isViolatingExceptSimpleRule(node)) {
@@ -93,6 +94,7 @@ module.exports = function (context) {
                         message: EXCEPT_SIMPLE_ERROR_MESSAGE,
                         data: assertionMessageData()
                     });
+                    currentTest.didReport = true;
                 }
             } else if (utils.isTest(node.callee)) {
                 captureTestContext(node);

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -275,6 +275,17 @@ ruleTester.run("require-expect", rule, {
             options: ["except-simple"]
         },
 
+        // Multiple assert statements only report one error per test
+        {
+            code: "test('name', function(assert) { maybe(function() { assert.ok(true); assert.ok(true); }) });",
+            errors: [{
+                message: exceptSimpleErrorMessage("assert.expect"),
+                column: 1,
+                type: "CallExpression"
+            }],
+            options: ["except-simple"]
+        },
+
         // "always" configration - simple case
         {
             code: "test('name', function(assert) { assert.ok(true) })",
@@ -294,6 +305,35 @@ ruleTester.run("require-expect", rule, {
             code: "test('name', function(assert) { other.expect(1); assert.ok(true); });",
             options: [],
             errors: [{ message: alwaysErrorMessage("assert.expect") }]
+        },
+
+        // "always" configuration - errors are reported on `test()` line
+        {
+            code: [
+                "module('some-module', function() {",
+                "    test('some-test', function(assert) {",
+                "        if (false) {",
+                "            assert.ok(true, 'needs expect');",
+                "        }",
+                "    });",
+                "});"
+            ].join(returnAndIndent),
+            options: [],
+            errors: [{
+                message: alwaysErrorMessage("assert.expect"),
+                type: "CallExpression",
+                line: 2
+            }]
+        },
+
+        // "always" configuration - multiple assert statements only report one error per test
+        {
+            code: "test('name', function(assert) { maybe(function() { assert.ok(true); assert.ok(true); }) });",
+            options: [],
+            errors: [{
+                message: alwaysErrorMessage("assert.expect"),
+                column: 1
+            }]
         }
     ]
 


### PR DESCRIPTION
This PR addresses #35.