### PR TITLE
Add "no-identical-names" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Below is the list of rules available in this plugin.
 * [no-global-expect](docs/rules/no-global-expect.md)
 * [no-global-module-test](docs/rules/no-global-module-test.md)
 * [no-global-stop-start](docs/rules/no-global-stop-start.md)
+* [no-identical-names](docs/rules/no-identical-names.md)
 * [no-init](docs/rules/no-init.md)
 * [no-jsdump](docs/rules/no-jsdump.md)
 * [no-negated-ok](docs/rules/no-negated-ok.md)

--- a/docs/rules/no-identical-names.md
+++ b/docs/rules/no-identical-names.md
@@ -1,0 +1,47 @@
+# Forbid identical test and module names (no-identical-names)
+
+Having identical names for two different tests or modules may create
+confusion. For example, when a test with the same name as another test
+in the same module fails, it is harder to know which one failed and
+thus harder to fix.
+
+## Rule Details
+
+This rule looks at the name of every test and module. It will report
+when two modules or two tests within a module have the same name.
+
+The following patterns are considered warnings:
+
+```js
+module("module1");
+test("it1", function() {});
+test("it1", function() {});
+```
+
+```js
+module("module1");
+test("it1", function() {});
+
+module("module1");
+test("it2", function() {});
+```
+
+The following patterns are not considered warnings:
+
+```js
+module("module1");
+test("it1", function() {});
+
+module("module2");
+test("it1", function() {});
+```
+
+## When Not to Use It
+
+If you are using nested modules you should not use this rule, as it does
+not support nested modules yet.
+
+## Further Reading
+
+* [QUnit.test()](http://api.qunitjs.com/QUnit.test/)
+* [QUnit.module()](http://api.qunitjs.com/QUnit.module/)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
         "no-global-module-test": require("./lib/rules/no-global-module-test"),
         "no-global-stop-start": require("./lib/rules/no-global-stop-start"),
         "no-early-return": require("./lib/rules/no-early-return"),
+        "no-identical-names": require("./lib/rules/no-identical-names"),
         "no-init": require("./lib/rules/no-init"),
         "no-jsdump": require("./lib/rules/no-jsdump"),
         "no-negated-ok": require("./lib/rules/no-negated-ok"),

--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Forbid identical test and module names
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Forbid identical test and module names",
+            category: "Possible Errors"
+        },
+        schema: []
+    },
+
+    create: function (context) {
+        var testNames = [];
+        var moduleNames = [];
+
+        //----------------------------------------------------------------------
+        // Helper functions
+        //----------------------------------------------------------------------
+
+        function isFirstArgLiteral(node) {
+            return node.arguments && node.arguments[0] && node.arguments[0].type === "Literal";
+        }
+
+        function handleTestNames(node, title) {
+            if (utils.isTest(node.callee)) {
+                if (testNames.indexOf(title) !== -1) {
+                    context.report({
+                        node: node.arguments[0],
+                        message: "Test name is used multiple times in the same module."
+                    });
+                }
+                testNames.push(title);
+            }
+        }
+
+        function handleModuleNames(node, title) {
+            if (utils.isModule(node.callee)) {
+                if (moduleNames.indexOf(title) !== -1) {
+                    context.report({
+                        node: node.arguments[0],
+                        message: "Module name is used multiple times."
+                    });
+                }
+                moduleNames.push(title);
+            }
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            "CallExpression": function (node) {
+                if (utils.isModule(node.callee)) {
+                    testNames = [];
+                }
+
+                if (!isFirstArgLiteral(node)) {
+                    return;
+                }
+
+                var title = node.arguments[0].value;
+                handleTestNames(node, title);
+                handleModuleNames(node, title);
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-identical-names.js
+++ b/tests/lib/rules/no-identical-names.js
@@ -1,0 +1,134 @@
+/* eslint-disable no-template-curly-in-string */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-identical-names"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run("no-identical-title", rule, {
+
+    valid: [
+        [
+            "module(\"module\");",
+            "test(\"test\", function() {});"
+        ].join("\n"),
+        [
+            "module(\"module1\");",
+            "test(\"it1\", function() {});",
+            "test(\"it2\", function() {});"
+        ].join("\n"),
+        [
+            "test(\"it1\", function() {});",
+            "test(\"it2\", function() {});"
+        ].join("\n"),
+        [
+            "module(\"title\", function() {});",
+            "test(\"title\", function() {});"
+        ].join("\n"),
+        [
+            "module(\"module1\");",
+            "test(\"it1\", function() {});",
+            "module(\"module2\");",
+            "test(\"it1\", function() {});"
+        ].join("\n"),
+        [
+            "module(\"module1\");",
+            "module(\"module2\");"
+        ].join("\n"),
+        [
+            "test(\"test\" + n, function() {});",
+            "test(\"test\" + n, function() {});"
+        ].join("\n"),
+        [
+            "module(\"module1\", function() {",
+            "  test(\"it1\", function() {});",
+            "  test(\"it2\", function() {});",
+            "});",
+            "module(\"module2\", function() {",
+            "  test(\"it1\", function() {});",
+            "  test(\"it2\", function() {});",
+            "});"
+        ].join("\n"),
+        {
+            code: [
+                "test(`it${n}`, function() {});",
+                "test(`it${n}`, function() {});"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        }
+    ],
+
+    invalid: [
+        {
+            code: [
+                "module(\"module1\");",
+                "test(\"it1\", function() {});",
+                "test(\"it1\", function() {});"
+            ].join("\n"),
+            errors: [{
+                message: "Test name is used multiple times in the same module.",
+                column: 6,
+                line: 3
+            }]
+        },
+        {
+            code: [
+                "test(\"it1\", function() {});",
+                "test(\"it1\", function() {});"
+            ].join("\n"),
+            errors: [{
+                message: "Test name is used multiple times in the same module.",
+                column: 6,
+                line: 2
+            }]
+        },
+        {
+            code: [
+                "module(\"module1\", function() {",
+                "  test(\"it1\", function() {});",
+                "  test(\"it1\", function() {});",
+                "});"
+            ].join("\n"),
+            errors: [{
+                message: "Test name is used multiple times in the same module.",
+                column: 8,
+                line: 3
+            }]
+        },
+        {
+            code: [
+                "module(\"module1\");",
+                "module(\"module1\");"
+            ].join("\n"),
+            errors: [{
+                message: "Module name is used multiple times.",
+                column: 8,
+                line: 2
+            }]
+        },
+        {
+            code: [
+                "module(\"module1\");",
+                "test(\"it\", function() {});",
+                "module(\"module1\");"
+            ].join("\n"),
+            errors: [{
+                message: "Module name is used multiple times.",
+                column: 8,
+                line: 3
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
This PR implements a `no-identical-names` rule similar to https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-identical-title.md but for QUnit.

Resolves #56 

/cc @platinumazure 