### PR TITLE
Docs: Fix heading syntax for no-assert-equal

### DIFF
--- a/docs/rules/no-assert-equal.md
+++ b/docs/rules/no-assert-equal.md
@@ -1,4 +1,4 @@
-#Forbid the use of assert.equal (no-assert-equal)
+# Forbid the use of assert.equal (no-assert-equal)
 
 The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 


### PR DESCRIPTION
Seems to render as literal `#Forbid` without the space.