### PR TITLE
Improve no-only rule to detect only() module.only() and QUnit.module.only()

### DIFF
--- a/docs/rules/no-only.md
+++ b/docs/rules/no-only.md
@@ -8,7 +8,13 @@ The following patterns are considered warnings:
 
 ```js
 
-QUnit.only('Name', function () { });
+QUnit.module.only('Name', function() { });
+
+QUnit.only('Name', function() { });
+
+module.only('Name', function() { });
+
+only('Name', function() { });
 
 ```
 
@@ -16,7 +22,13 @@ The following patterns are not considered warnings:
 
 ```js
 
-QUnit.test('Name', function () { });
+QUnit.module.test('Name', function() { });
+
+QUnit.test('Name', function() { });
+
+module.test('Name', function() { });
+
+test('Name', function() { });
 
 ```
 

--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const utils = require("../utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -15,18 +21,23 @@ module.exports = {
             category: "Best Practices"
         },
         messages: {
-            noQUnitOnly: "Unexpected QUnit.only call."
+            noQUnitOnly: "Unexpected only() call."
         },
         schema: []
     },
 
     create: function (context) {
         return {
-            "CallExpression[callee.object.name='QUnit'][callee.property.name='only']": function (node) {
-                context.report({
-                    node: node,
-                    messageId: "noQUnitOnly"
-                });
+            "CallExpression": function (node) {
+                if (utils.isOnly(node.callee)) {
+                    context.report({
+                        node: node,
+                        messageId: "noQUnitOnly",
+                        data: {
+                            callee: node.callee.name
+                        }
+                    });
+                }
             }
         };
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@
  */
 "use strict";
 
-const SUPPORTED_TEST_IDENTIFIERS = ["test", "asyncTest"];
+const SUPPORTED_TEST_IDENTIFIERS = ["test", "asyncTest", "only"];
 
 const OLD_MODULE_HOOK_IDENTIFIERS = ["setup", "teardown"];
 const NEW_MODULE_HOOK_IDENTIFIERS = ["beforeEach", "afterEach"];
@@ -167,6 +167,27 @@ exports.isAsyncTest = function (calleeNode) {
             calleeNode.object.name === "QUnit" &&
             calleeNode.property.type === "Identifier" &&
             calleeNode.property.name === "asyncTest";
+    }
+
+    return result;
+};
+
+exports.isOnly = function (calleeNode) {
+    let result = false;
+
+    /* istanbul ignore else: will correctly return false */
+    if (calleeNode.type === "Identifier") {
+        // only()
+        result = calleeNode.name === "only";
+    } else if (calleeNode.type === "MemberExpression" && calleeNode.property.type === "Identifier" && calleeNode.property.name === "only") {
+        if (calleeNode.object.type === "Identifier") {
+            // QUnit.only() or module.only()
+            result = calleeNode.object.name === "QUnit" || calleeNode.object.name === "module";
+        } else if (calleeNode.object.type === "MemberExpression") {
+            // QUnit.*.only()
+            result = calleeNode.object.object.type === "Identifier" &&
+                calleeNode.object.object.name === "QUnit";
+        }
     }
 
     return result;

--- a/tests/lib/rules/no-only.js
+++ b/tests/lib/rules/no-only.js
@@ -19,15 +19,33 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("no-only", rule, {
     valid: [
+        "QUnit.module.test('Name', function() { });",
         "QUnit.test('Name', function() { });",
-
-        // QUnit.only is not exposed globally so this is valid
-        "only('Name', function() { });"
+        "module.test('Name', function() { });",
+        "test('Name', function() { });"
     ],
 
     invalid: [
         {
+            code: "QUnit.module.only('Name', function() { });",
+            errors: [{
+                messageId: "noQUnitOnly"
+            }]
+        },
+        {
             code: "QUnit.only('Name', function() { });",
+            errors: [{
+                messageId: "noQUnitOnly"
+            }]
+        },
+        {
+            code: "module.only('Name', function() { });",
+            errors: [{
+                messageId: "noQUnitOnly"
+            }]
+        },
+        {
+            code: "only('Name', function() { });",
             errors: [{
                 messageId: "noQUnitOnly"
             }]


### PR DESCRIPTION
Fixes https://github.com/platinumazure/eslint-plugin-qunit/issues/72

@platinumazure I'm no eslint expert, but this seems to pass all the tests. Let me know if there's more I need to do