### PR TITLE
Implement new rule `no-assert-ok`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Below is the list of rules available in this plugin.
 * [no-arrow-tests](docs/rules/no-arrow-tests.md)
 * [no-assert-equal](docs/rules/no-assert-equal.md)
 * [no-assert-logical-expression](docs/rules/no-assert-logical-expression.md)
+* [no-assert-ok](docs/rules/no-assert-ok.md)
 * [no-async-in-loops](docs/rules/no-async-in-loops.md)
 * [no-async-test](docs/rules/no-async-test.md)
 * [no-commented-tests](docs/rules/no-commented-tests.md)

--- a/docs/rules/no-assert-ok.md
+++ b/docs/rules/no-assert-ok.md
@@ -1,0 +1,34 @@
+# Forbid the use of assert.ok/assert.notOk (no-assert-ok)
+
+`assert.ok` and `assert.notOk` pass for any truthy/falsy argument. As [many expressions evaluate to true/false in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) the usage of `assert.ok` is potentially error prone. In general, it should be advisable to always test for exact values in tests which makes tests a lot more solid.
+
+An example when using `assert.ok` can involuntarily go wrong:
+```
+test('test myFunc returns a truthy value' (assert) => {
+  assert.ok(myFunc);
+});
+```
+Here by mistake a developer just passed to `assert.ok` a pointer to `myFunc` instead of explicitly calling it. This test is going pass no matter how `myFunc` changes. Using `assert.strictEqual(myFunc, theReturnValue)` solves the problem as this becomes an explicit check for equality.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+
+QUnit.test('Name', function (assert) { assert.ok(a); });
+
+QUnit.test('Name', function (foo) { foo.ok(a); });
+
+QUnit.test('Name', function () { ok(a); });
+
+QUnit.test('Name', function (assert) { assert.notOk(a); });
+
+QUnit.test('Name', function (foo) { foo.notOk(a); });
+
+QUnit.test('Name', function () { notOk(a); });
+
+```
+## Further Reading
+
+* [QUnit's Assertions](https://api.qunitjs.com/category/assert/)

--- a/docs/rules/no-assert-ok.md
+++ b/docs/rules/no-assert-ok.md
@@ -29,6 +29,37 @@ QUnit.test('Name', function (foo) { foo.notOk(a); });
 QUnit.test('Name', function () { notOk(a); });
 
 ```
+
+The following patterns are not considered warnings:
+
+```js
+
+QUnit.test('Name', function (assert) { assert.strictEqual(a, true); });
+
+QUnit.test('Name', function (foo) { foo.strictEqual(a, true); });
+
+QUnit.test('Name', function () { strictEqual(a, true); });
+
+QUnit.test('Name', function (assert) { assert.strictEqual(a, false); });
+
+QUnit.test('Name', function (foo) { foo.strictEqual(a, false); });
+
+QUnit.test('Name', function () { strictEqual(a, false); });
+
+QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });
+
+QUnit.test('Name', function (foo) { foo.deepEqual(a, b); });
+
+QUnit.test('Name', function () { deepEqual(a, b); });
+
+QUnit.test('Name', function (assert) { assert.propEqual(a, b); });
+
+QUnit.test('Name', function (foo) { foo.propEqual(a, b); });
+
+QUnit.test('Name', function () { propEqual(a, b); });
+
+```
+
 ## Further Reading
 
 * [QUnit's Assertions](https://api.qunitjs.com/category/assert/)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
         "no-arrow-tests": require("./lib/rules/no-arrow-tests"),
         "no-assert-equal": require("./lib/rules/no-assert-equal"),
         "no-assert-logical-expression": require("./lib/rules/no-assert-logical-expression"),
+        "no-assert-ok": require("./lib/rules/no-assert-ok"),
         "no-async-in-loops": require("./lib/rules/no-async-in-loops"),
         "no-async-test": require("./lib/rules/no-async-test"),
         "no-commented-tests": require("./lib/rules/no-commented-tests"),

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -13,8 +13,8 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalEqual";
-const LOCAL_ERROR_MESSAGE_ID = "unexpectedAssertEqual";
+const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalOkNotOk";
+const LOCAL_ERROR_MESSAGE_ID = "unexpectedLocalOkNotOk";
 const assertions = ["ok", "notOk"];
 
 module.exports = {

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Forbid the use of assert.ok/assert.notOk and suggest other assertions.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalEqual";
+const LOCAL_ERROR_MESSAGE_ID = "unexpectedAssertEqual";
+const assertions = ["ok", "notOk"];
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "forbid the use of assert.ok/assert.notOk",
+            category: "Best Practices"
+        },
+        messages: {
+            [GLOBAL_ERROR_MESSAGE_ID]: "Unexpected {{assertion}}. Use strictEqual, deepEqual, or propEqual.",
+            [LOCAL_ERROR_MESSAGE_ID]: "Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
+        },
+        schema: []
+    },
+
+    create: utils.createAssertionCheck(assertions, GLOBAL_ERROR_MESSAGE_ID, LOCAL_ERROR_MESSAGE_ID)
+};

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Forbid the use of assert.ok/assert.notOk and suggest other assertions.
+ * @author ventuno
  */
 "use strict";
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const assert = require("assert");
+
 const SUPPORTED_TEST_IDENTIFIERS = ["test", "asyncTest", "only"];
 
 const OLD_MODULE_HOOK_IDENTIFIERS = ["setup", "teardown"];
@@ -231,4 +233,72 @@ exports.shouldCompareActualFirst = function (calleeNode, assertVar) {
     const assertionMetadata = getAssertionMetadata(calleeNode, assertVar);
 
     return assertionMetadata && assertionMetadata.compareActualFirst;
+};
+
+exports.createAssertionCheck = function (assertions, unexpectedGlobalAssertion, unexpectedLocalAssertion) {
+    return function (context) {
+        // Declare a test stack in case of nested test cases (not currently
+        // supported by QUnit).
+        const testStack = [];
+
+        function isGlobalAssertion(calleeNode) {
+            return calleeNode &&
+                calleeNode.type === "Identifier" &&
+                assertions.includes(calleeNode.name);
+        }
+
+        function getCurrentAssertContextVariable() {
+            assert(testStack.length, "Test stack should not be empty");
+
+            return testStack[testStack.length - 1].assertVar;
+        }
+
+        function isMethodCalledOnLocalAssertObject(calleeNode) {
+            return calleeNode &&
+                calleeNode.type === "MemberExpression" &&
+                calleeNode.property.type === "Identifier" &&
+                assertions.includes(calleeNode.property.name) &&
+                calleeNode.object.type === "Identifier" &&
+                calleeNode.object.name === getCurrentAssertContextVariable();
+        }
+
+        function isExpectedAssertion(calleeNode) {
+            return isGlobalAssertion(calleeNode) ||
+                isMethodCalledOnLocalAssertObject(calleeNode);
+        }
+
+        function reportError(node) {
+            const assertVar = getCurrentAssertContextVariable();
+            const isGlobal = isGlobalAssertion(node.callee);
+            const assertion = isGlobal ? node.callee.name : node.callee.property.name;
+
+            context.report({
+                node: node,
+                messageId: isGlobalAssertion(node.callee) ? unexpectedGlobalAssertion : unexpectedLocalAssertion,
+                data: {
+                    assertVar,
+                    assertion
+                }
+            });
+        }
+
+        return {
+            "CallExpression": function (node) {
+                /* istanbul ignore else: correctly does nothing */
+                if (exports.isTest(node.callee) || exports.isAsyncTest(node.callee)) {
+                    testStack.push({
+                        assertVar: exports.getAssertContextNameForTest(node.arguments)
+                    });
+                } else if (testStack.length && isExpectedAssertion(node.callee)) {
+                    reportError(node);
+                }
+            },
+            "CallExpression:exit": function (node) {
+                /* istanbul ignore else: correctly does nothing */
+                if (exports.isTest(node.callee) || exports.isAsyncTest(node.callee)) {
+                    testStack.pop();
+                }
+            }
+        };
+    };
 };

--- a/tests/lib/rules/no-assert-ok.js
+++ b/tests/lib/rules/no-assert-ok.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Forbid the use of assert.ok/notOk and suggest other assertions.
+ * @author Kevin Partington
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-assert-ok"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-assert-ok", rule, {
+    valid: [
+        "QUnit.test('Name', function (assert) { assert.strictEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { assert.propEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.strictEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.deepEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.propEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { strictEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { deepEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { propEqual(a, b); });",
+        "QUnit.test('Name', function () { strictEqual(a, b); });",
+        "QUnit.test('Name', function () { deepEqual(a, b); });",
+        "QUnit.test('Name', function () { propEqual(a, b); });",
+
+        // equal is not within test context
+        "equal(a, b);"
+    ],
+
+    invalid: [
+        {
+            code: "QUnit.test('Name', function (assert) { assert.ok(a); });",
+            errors: [{
+                messageId: "unexpectedAssertEqual",
+                data: { assertVar: "assert",
+                    assertion: "ok" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (foo) { foo.ok(a); });",
+            errors: [{
+                messageId: "unexpectedAssertEqual",
+                data: { assertVar: "foo",
+                    assertion: "ok" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.notOk(a); });",
+            errors: [{
+                messageId: "unexpectedAssertEqual",
+                data: { assertVar: "assert",
+                    assertion: "notOk" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (foo) { foo.notOk(a); });",
+            errors: [{
+                messageId: "unexpectedAssertEqual",
+                data: { assertVar: "foo",
+                    assertion: "notOk" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { ok(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalEqual",
+                data: { assertion: "ok" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { notOk(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalEqual",
+                data: { assertion: "notOk" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function () { ok(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalEqual",
+                data: { assertion: "ok" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function () { notOk(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalEqual",
+                data: { assertion: "notOk" }
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/no-assert-ok.js
+++ b/tests/lib/rules/no-assert-ok.js
@@ -40,7 +40,7 @@ ruleTester.run("no-assert-ok", rule, {
         {
             code: "QUnit.test('Name', function (assert) { assert.ok(a); });",
             errors: [{
-                messageId: "unexpectedAssertEqual",
+                messageId: "unexpectedLocalOkNotOk",
                 data: { assertVar: "assert",
                     assertion: "ok" }
             }]
@@ -48,7 +48,7 @@ ruleTester.run("no-assert-ok", rule, {
         {
             code: "QUnit.test('Name', function (foo) { foo.ok(a); });",
             errors: [{
-                messageId: "unexpectedAssertEqual",
+                messageId: "unexpectedLocalOkNotOk",
                 data: { assertVar: "foo",
                     assertion: "ok" }
             }]
@@ -56,7 +56,7 @@ ruleTester.run("no-assert-ok", rule, {
         {
             code: "QUnit.test('Name', function (assert) { assert.notOk(a); });",
             errors: [{
-                messageId: "unexpectedAssertEqual",
+                messageId: "unexpectedLocalOkNotOk",
                 data: { assertVar: "assert",
                     assertion: "notOk" }
             }]
@@ -64,7 +64,7 @@ ruleTester.run("no-assert-ok", rule, {
         {
             code: "QUnit.test('Name', function (foo) { foo.notOk(a); });",
             errors: [{
-                messageId: "unexpectedAssertEqual",
+                messageId: "unexpectedLocalOkNotOk",
                 data: { assertVar: "foo",
                     assertion: "notOk" }
             }]
@@ -72,28 +72,28 @@ ruleTester.run("no-assert-ok", rule, {
         {
             code: "QUnit.test('Name', function (assert) { ok(a, b); });",
             errors: [{
-                messageId: "unexpectedGlobalEqual",
+                messageId: "unexpectedGlobalOkNotOk",
                 data: { assertion: "ok" }
             }]
         },
         {
             code: "QUnit.test('Name', function (assert) { notOk(a, b); });",
             errors: [{
-                messageId: "unexpectedGlobalEqual",
+                messageId: "unexpectedGlobalOkNotOk",
                 data: { assertion: "notOk" }
             }]
         },
         {
             code: "QUnit.test('Name', function () { ok(a, b); });",
             errors: [{
-                messageId: "unexpectedGlobalEqual",
+                messageId: "unexpectedGlobalOkNotOk",
                 data: { assertion: "ok" }
             }]
         },
         {
             code: "QUnit.test('Name', function () { notOk(a, b); });",
             errors: [{
-                messageId: "unexpectedGlobalEqual",
+                messageId: "unexpectedGlobalOkNotOk",
                 data: { assertion: "notOk" }
             }]
         }

--- a/tests/lib/rules/no-assert-ok.js
+++ b/tests/lib/rules/no-assert-ok.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Forbid the use of assert.ok/notOk and suggest other assertions.
- * @author Kevin Partington
+ * @author ventuno
  */
 "use strict";
 
@@ -41,32 +41,40 @@ ruleTester.run("no-assert-ok", rule, {
             code: "QUnit.test('Name', function (assert) { assert.ok(a); });",
             errors: [{
                 messageId: "unexpectedLocalOkNotOk",
-                data: { assertVar: "assert",
-                    assertion: "ok" }
+                data: {
+                    assertVar: "assert",
+                    assertion: "ok"
+                }
             }]
         },
         {
             code: "QUnit.test('Name', function (foo) { foo.ok(a); });",
             errors: [{
                 messageId: "unexpectedLocalOkNotOk",
-                data: { assertVar: "foo",
-                    assertion: "ok" }
+                data: {
+                    assertVar: "foo",
+                    assertion: "ok"
+                }
             }]
         },
         {
             code: "QUnit.test('Name', function (assert) { assert.notOk(a); });",
             errors: [{
                 messageId: "unexpectedLocalOkNotOk",
-                data: { assertVar: "assert",
-                    assertion: "notOk" }
+                data: {
+                    assertVar: "assert",
+                    assertion: "notOk"
+                }
             }]
         },
         {
             code: "QUnit.test('Name', function (foo) { foo.notOk(a); });",
             errors: [{
                 messageId: "unexpectedLocalOkNotOk",
-                data: { assertVar: "foo",
-                    assertion: "notOk" }
+                data: {
+                    assertVar: "foo",
+                    assertion: "notOk"
+                }
             }]
         },
         {


### PR DESCRIPTION
@platinumazure here's my attempt at implementing #77.

Apologies for this not being super polished, but I wanted to have something out to make sure we were on the same page.
A few notes:
1) The general idea behind this is to provide a function (`createAssertionCheck` -- still thinking of a better name) that can look for usages of assertions (global or against the local `assert` object);
2) For example, based on the above `no-assert-equal` could for example be refactored as:
```
// metadata ...
meta: {
    // ...
    messages: {
        unexpectedGlobalEqual: "Unexpected equal. Use strictEqual, deepEqual, or propEqual.",
        unexpectedAssertEqual: "Unexpected {{assertVar}}.equal. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
    },
    // ...
},
create: utils.createAssertionCheck(["equal"], "unexpectedGlobalEqual", "unexpectedAssertEqual")
```
3) Similarly [`no-loose-assertions`](https://github.com/platinumazure/eslint-plugin-qunit/issues/77#issuecomment-589258915) could be implemented as:
```
// metadata ...
meta: {
    // ...
    messages: {
        unexpectedGlobalLooseAssertion: "Unexpected {{assertion}}. Use ...",
        unexpectedLocalLooseAssertion: "Unexpected {{assertVar}}.{{assertion}}. Use ..."
    },
    // ...
},
create: function(context) {
    const defaultOptions = ["equal", "ok", "notOk"];
    // Allow users to configure which assertions they want to use.
    const options = overrideDefaults(context.options, defaultOptions);
    return utils.createAssertionCheck(options, "unexpectedGlobalLooseAssertion", "unexpectedLocalLooseAssertion").call(this, context);
}
```
4) Finally `utils` may not be the best place for `createAssertionCheck` maybe it could live in its own utility file?

TODO:
- [x] docs;
- [x] export new rule.