### PR TITLE
New no-loose-assertions rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Below is the list of rules available in this plugin.
 * [no-identical-names](docs/rules/no-identical-names.md)
 * [no-init](docs/rules/no-init.md)
 * [no-jsdump](docs/rules/no-jsdump.md)
+* [no-loose-assertions](docs/rules/no-loose-assertions.md)
 * [no-negated-ok](docs/rules/no-negated-ok.md)
 * [no-ok-equality](docs/rules/no-ok-equality.md)
 * [no-only](docs/rules/no-only.md)

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -1,6 +1,6 @@
 # Forbid the use of assert.equal/assert.notEqual/assert.ok/assert.notOk (no-loose-assertions)
 
-The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
+The `assert.equal`/`assert.notEqual` assertions method in QUnit use loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual`/`assert.notStrictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 
 `assert.ok` and `assert.notOk` pass for any truthy/falsy argument. As [many expressions evaluate to true/false in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) the usage of `assert.ok` is potentially error prone. In general, it should be advisable to always test for exact values in tests which makes tests a lot more solid.
 
@@ -79,6 +79,9 @@ QUnit.test('Name', function (assert) { assert.propEqual(a, b); });
 QUnit.test('Name', function (foo) { foo.propEqual(a, b); });
 
 QUnit.test('Name', function () { propEqual(a, b); });
+
+/* eslint no-loose-assertions: ["error", ["strictEqual", "ok", "notOk"]] */
+QUnit.test('Name', function (assert) { assert.notEqual(a, b); });
 
 ```
 

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -1,0 +1,75 @@
+# Forbid the use of assert.equal/assert.ok/assert.notOk (no-loose-assertions)
+
+The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
+
+`assert.ok` and `assert.notOk` pass for any truthy/falsy argument. As [many expressions evaluate to true/false in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) the usage of `assert.ok` is potentially error prone. In general, it should be advisable to always test for exact values in tests which makes tests a lot more solid.
+
+An example when using `assert.ok` can involuntarily go wrong:
+```
+test('test myFunc returns a truthy value' (assert) => {
+  assert.ok(myFunc);
+});
+```
+Here by mistake a developer just passed to `assert.ok` a pointer to `myFunc` instead of explicitly calling it. This test is going pass no matter how `myFunc` changes. Using `assert.strictEqual(myFunc, theReturnValue)` solves the problem as this becomes an explicit check for equality.
+
+The assertions to lint against can be controlled with an array of assertions (default `["equal", "ok", "notOk"]`).
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+
+QUnit.test('Name', function (assert) { assert.ok(a); });
+
+QUnit.test('Name', function (foo) { foo.ok(a); });
+
+QUnit.test('Name', function () { ok(a); });
+
+QUnit.test('Name', function (assert) { assert.notOk(a); });
+
+QUnit.test('Name', function (foo) { foo.notOk(a); });
+
+QUnit.test('Name', function () { notOk(a); });
+
+QUnit.test('Name', function (assert) { assert.equal(a, b); });
+
+QUnit.test('Name', function (foo) { foo.equal(a, b); });
+
+QUnit.test('Name', function () { equal(a, b); });
+
+```
+
+The following patterns are not considered warnings:
+
+```js
+
+QUnit.test('Name', function (assert) { assert.strictEqual(a, true); });
+
+QUnit.test('Name', function (foo) { foo.strictEqual(a, true); });
+
+QUnit.test('Name', function () { strictEqual(a, true); });
+
+QUnit.test('Name', function (assert) { assert.strictEqual(a, false); });
+
+QUnit.test('Name', function (foo) { foo.strictEqual(a, false); });
+
+QUnit.test('Name', function () { strictEqual(a, false); });
+
+QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });
+
+QUnit.test('Name', function (foo) { foo.deepEqual(a, b); });
+
+QUnit.test('Name', function () { deepEqual(a, b); });
+
+QUnit.test('Name', function (assert) { assert.propEqual(a, b); });
+
+QUnit.test('Name', function (foo) { foo.propEqual(a, b); });
+
+QUnit.test('Name', function () { propEqual(a, b); });
+
+```
+
+## Further Reading
+
+* [QUnit's Assertions](https://api.qunitjs.com/category/assert/)

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -12,7 +12,7 @@ test('test myFunc returns a truthy value' (assert) => {
 ```
 Here by mistake a developer just passed to `assert.ok` a pointer to `myFunc` instead of explicitly calling it. This test is going pass no matter how `myFunc` changes. Using `assert.strictEqual(myFunc, theReturnValue)` solves the problem as this becomes an explicit check for equality.
 
-The assertions to lint against can be controlled with an array of assertions (default `["equal", "ok", "notOk"]`).
+The assertions to lint against can be controlled with an array of assertions (default `["equal", "notEqual", "ok", "notOk"]`).
 
 To fine tune the error message (which by default will recommend to use `strictEqual`, `notStrictEqual`, `deepEqual`, or `propEqual`) a configuration object can be passed as an option instead of a string. The configuration object has two properties:
 * `disallowed`: the name of the assertion to disallow (either `equal`, `ok`, or `notOk`);

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -1,4 +1,4 @@
-# Forbid the use of assert.equal/assert.ok/assert.notOk (no-loose-assertions)
+# Forbid the use of assert.equal/assert.ok/assert.notStrictEqual/assert.notOk (no-loose-assertions)
 
 The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 
@@ -14,7 +14,7 @@ Here by mistake a developer just passed to `assert.ok` a pointer to `myFunc` ins
 
 The assertions to lint against can be controlled with an array of assertions (default `["equal", "ok", "notOk"]`).
 
-To fine tune the error message (which by default will recommend to use `strictEqual`, `deepEqual`, or `propEqual`) a configuration object can be passed as an option instead of a string. The configuration object has two properties:
+To fine tune the error message (which by default will recommend to use `strictEqual`, `notStrictEqual`, `deepEqual`, or `propEqual`) a configuration object can be passed as an option instead of a string. The configuration object has two properties:
 * `disallowed`: the name of the assertion to disallow (either `equal`, `ok`, or `notOk`);
 * `recommended`: an array of strings representing the recommended options to display as an error message. The strings in the array will be concatenated to build the error message: `Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.<recommended_1>, {{assertVar}}.<recommended_2>.` when using local assertions and `Unexpected {{assertion}}. Use <recommended_1>, <recommended_2>.` when using global assertions.
 
@@ -56,11 +56,11 @@ QUnit.test('Name', function (foo) { foo.strictEqual(a, true); });
 
 QUnit.test('Name', function () { strictEqual(a, true); });
 
-QUnit.test('Name', function (assert) { assert.strictEqual(a, false); });
+QUnit.test('Name', function (assert) { assert.notStrictEqual(a, false); });
 
-QUnit.test('Name', function (foo) { foo.strictEqual(a, false); });
+QUnit.test('Name', function (foo) { foo.notStrictEqual(a, false); });
 
-QUnit.test('Name', function () { strictEqual(a, false); });
+QUnit.test('Name', function () { notStrictEqual(a, false); });
 
 QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });
 

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -14,6 +14,12 @@ Here by mistake a developer just passed to `assert.ok` a pointer to `myFunc` ins
 
 The assertions to lint against can be controlled with an array of assertions (default `["equal", "ok", "notOk"]`).
 
+To fine tune the error message (which by default will recommend to use `strictEqual`, `deepEqual`, or `propEqual`) a configuration object can be passed as an option instead of a string. The configuration object has two properties:
+* `disallowed`: the name of the assertion to disallow (either `equal`, `ok`, or `notOk`);
+* `recommended`: an array of strings representing the recommended options to display as an error message. The strings in the array will be concatenated to build the error message: `Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.<recommended_1>, {{assertVar}}.<recommended_2>.` when using local assertions and `Unexpected {{assertion}}. Use <recommended_1>, <recommended_2>.` when using global assertions.
+
+If an assertion is passed twice as a string and object the first configuration will be used and any other configuration will be ignored.
+
 ## Rule Details
 
 The following patterns are considered warnings:

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -1,6 +1,6 @@
 # Forbid the use of assert.equal/assert.notEqual/assert.ok/assert.notOk (no-loose-assertions)
 
-The `assert.equal`/`assert.notEqual` assertions method in QUnit use loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual`/`assert.notStrictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
+The `assert.equal`/`assert.notEqual` assertion methods in QUnit use loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual`/`assert.notStrictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 
 `assert.ok` and `assert.notOk` pass for any truthy/falsy argument. As [many expressions evaluate to true/false in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) the usage of `assert.ok` is potentially error prone. In general, it should be advisable to always test for exact values in tests which makes tests a lot more solid.
 

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -44,6 +44,12 @@ QUnit.test('Name', function (foo) { foo.equal(a, b); });
 
 QUnit.test('Name', function () { equal(a, b); });
 
+QUnit.test('Name', function (assert) { assert.notEqual(a, b); });
+
+QUnit.test('Name', function (foo) { foo.notEqual(a, b); });
+
+QUnit.test('Name', function () { notEqual(a, b); });
+
 ```
 
 The following patterns are not considered warnings:

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -1,4 +1,4 @@
-# Forbid the use of assert.equal/assert.ok/assert.notStrictEqual/assert.notOk (no-loose-assertions)
+# Forbid the use of assert.equal/assert.notEqual/assert.ok/assert.notOk (no-loose-assertions)
 
 The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
         "no-identical-names": require("./lib/rules/no-identical-names"),
         "no-init": require("./lib/rules/no-init"),
         "no-jsdump": require("./lib/rules/no-jsdump"),
+        "no-loose-assertions": require("./lib/rules/no-assert-ok"),
         "no-negated-ok": require("./lib/rules/no-negated-ok"),
         "no-ok-equality": require("./lib/rules/no-ok-equality"),
         "no-only": require("./lib/rules/no-only"),

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -17,6 +17,12 @@ const utils = require("../utils");
 const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalOkNotOk";
 const LOCAL_ERROR_MESSAGE_ID = "unexpectedLocalOkNotOk";
 const assertions = ["ok", "notOk"];
+const ERROR_MESSAGE_CONFIG = {
+    ok: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
+        unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID },
+    notOk: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
+        unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID }
+};
 
 module.exports = {
     meta: {
@@ -31,5 +37,5 @@ module.exports = {
         schema: []
     },
 
-    create: utils.createAssertionCheck(assertions, GLOBAL_ERROR_MESSAGE_ID, LOCAL_ERROR_MESSAGE_ID)
+    create: utils.createAssertionCheck(assertions, ERROR_MESSAGE_CONFIG)
 };

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Forbid the use of assert.equal/assert.ok/assert.notOk and suggest other assertions.
+ * @author ventuno
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalLooseAssertion";
+const LOCAL_ERROR_MESSAGE_ID = "unexpectedLocalLooseAssertion";
+const DEFAULT_ASSERTIONS = ["equal", "ok", "notOk"];
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "forbid the use of assert.equal/assert.ok/assert.notOk (can be configured)",
+            category: "Best Practices"
+        },
+        messages: {
+            [GLOBAL_ERROR_MESSAGE_ID]: "Unexpected {{assertion}}. Use strictEqual, deepEqual, or propEqual.",
+            [LOCAL_ERROR_MESSAGE_ID]: "Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
+        },
+        schema: [{
+            type: "array",
+            minItems: 1,
+            items: { enum: DEFAULT_ASSERTIONS },
+            uniqueItems: true
+        }]
+    },
+
+    create: function (context) {
+        const assertions = context.options[0] || DEFAULT_ASSERTIONS;
+        return utils.createAssertionCheck(assertions, "unexpectedGlobalLooseAssertion", "unexpectedLocalLooseAssertion").call(this, context);
+    }
+};

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -48,7 +48,7 @@ function parseOptions(options) {
                 }
                 assertions.push(assertion);
                 errorMessageConfig[assertion] = ERROR_MESSAGE_CONFIG[assertion];
-            } else if (typeof assertion === "object") {
+            } else {
                 // Skip if rule was defined before.
                 if (assertions.includes(assertion.disallowed)) {
                     return;

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -16,12 +16,14 @@ const utils = require("../utils");
 
 const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalLooseAssertion";
 const LOCAL_ERROR_MESSAGE_ID = "unexpectedLocalLooseAssertion";
-const DEFAULT_ASSERTIONS = ["equal", "ok", "notOk"];
+const DEFAULT_ASSERTIONS = ["equal", "ok", "notEqual", "notOk"];
 
 const ERROR_MESSAGE_CONFIG = {
     equal: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
         unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID },
     ok: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
+        unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID },
+    notEqual: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
         unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID },
     notOk: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
         unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID }
@@ -65,12 +67,12 @@ function parseOptions(options) {
 module.exports = {
     meta: {
         docs: {
-            description: "forbid the use of assert.equal/assert.ok/assert.notOk (can be configured)",
+            description: "forbid the use of assert.equal/assert.ok/assert.notEqual/assert.notOk (can be configured)",
             category: "Best Practices"
         },
         messages: {
-            [GLOBAL_ERROR_MESSAGE_ID]: "Unexpected {{assertion}}. Use strictEqual, deepEqual, or propEqual.",
-            [LOCAL_ERROR_MESSAGE_ID]: "Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
+            [GLOBAL_ERROR_MESSAGE_ID]: "Unexpected {{assertion}}. Use strictEqual, notStrictEqual, deepEqual, or propEqual.",
+            [LOCAL_ERROR_MESSAGE_ID]: "Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.strictEqual, {{assertVar}}.notStrictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
         },
         schema: [{
             type: "array",

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -18,6 +18,50 @@ const GLOBAL_ERROR_MESSAGE_ID = "unexpectedGlobalLooseAssertion";
 const LOCAL_ERROR_MESSAGE_ID = "unexpectedLocalLooseAssertion";
 const DEFAULT_ASSERTIONS = ["equal", "ok", "notOk"];
 
+const ERROR_MESSAGE_CONFIG = {
+    equal: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
+        unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID },
+    ok: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
+        unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID },
+    notOk: { unexpectedGlobalAssertionMessageId: GLOBAL_ERROR_MESSAGE_ID,
+        unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID }
+};
+
+function buildErrorMessage(disallowed) {
+    const globalMessage = `Unexpected {{assertion}}. Use ${disallowed.join(", ")}.`;
+    const localMessasge = `Unexpected {{assertVar}}.{{assertion}}. Use ${disallowed.map((ass) => `{{assertVar}}.${ass}`).join(", ")}.`;
+    return {
+        unexpectedGlobalAssertionMessage: globalMessage,
+        unexpectedLocalAssertionMessage: localMessasge
+    };
+}
+
+function parseOptions(options) {
+    if (options[0]) {
+        const assertions = [];
+        const errorMessageConfig = {};
+        options[0].forEach((assertion) => {
+            if (typeof assertion === "string") {
+                // Skip if rule was defined before.
+                if (assertions.includes(assertion)) {
+                    return;
+                }
+                assertions.push(assertion);
+                errorMessageConfig[assertion] = ERROR_MESSAGE_CONFIG[assertion];
+            } else if (typeof assertion === "object") {
+                // Skip if rule was defined before.
+                if (assertions.includes(assertion.disallowed)) {
+                    return;
+                }
+                assertions.push(assertion.disallowed);
+                errorMessageConfig[assertion.disallowed] = buildErrorMessage(assertion.recommended);
+            }
+        });
+        return [assertions, errorMessageConfig];
+    }
+    return [DEFAULT_ASSERTIONS, ERROR_MESSAGE_CONFIG];
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -31,13 +75,35 @@ module.exports = {
         schema: [{
             type: "array",
             minItems: 1,
-            items: { enum: DEFAULT_ASSERTIONS },
+            items: {
+                oneOf: [{
+                    type: "object",
+                    properties: {
+                        disallowed: {
+                            type: "string",
+                            enum: DEFAULT_ASSERTIONS
+                        },
+                        recommended: {
+                            type: "array",
+                            items: {
+                                type: "string",
+                                minItems: 1
+                            }
+                        }
+                    },
+                    required: ["disallowed", "recommended"],
+                    additionalProperties: false
+                }, {
+                    type: "string",
+                    enum: DEFAULT_ASSERTIONS
+                }]
+            },
             uniqueItems: true
         }]
     },
 
     create: function (context) {
-        const assertions = context.options[0] || DEFAULT_ASSERTIONS;
-        return utils.createAssertionCheck(assertions, "unexpectedGlobalLooseAssertion", "unexpectedLocalLooseAssertion").call(this, context);
+        const [assertions, errorMessageConfig] = parseOptions(context.options);
+        return utils.createAssertionCheck(assertions, errorMessageConfig).call(this, context);
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -289,7 +289,9 @@ exports.createAssertionCheck = function (assertions, errorMessageConfig) {
                 }
             };
             const errorMessageConfigForAssertion = errorMessageConfig[assertion];
+            /* istanbul ignore else: correctly does nothing */
             if (errorMessageConfigForAssertion) {
+                /* istanbul ignore else: correctly does nothing */
                 if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId && errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId) {
                     reportErrorObject.messageId = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId : errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId;
                 } else if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage && errorMessageConfigForAssertion.unexpectedLocalAssertionMessage) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -244,7 +244,7 @@ exports.shouldCompareActualFirst = function (calleeNode, assertVar) {
     return assertionMetadata && assertionMetadata.compareActualFirst;
 };
 
-exports.createAssertionCheck = function (assertions, unexpectedGlobalAssertion, unexpectedLocalAssertion) {
+exports.createAssertionCheck = function (assertions, errorMessageConfig) {
     return function (context) {
         // Declare a test stack in case of nested test cases (not currently
         // supported by QUnit).
@@ -281,14 +281,28 @@ exports.createAssertionCheck = function (assertions, unexpectedGlobalAssertion, 
             const isGlobal = isGlobalAssertion(node.callee);
             const assertion = isGlobal ? node.callee.name : node.callee.property.name;
 
-            context.report({
-                node: node,
-                messageId: isGlobalAssertion(node.callee) ? unexpectedGlobalAssertion : unexpectedLocalAssertion,
+            const reportErrorObject = {
+                node,
                 data: {
                     assertVar,
                     assertion
                 }
-            });
+            };
+            const errorMessageConfigForAssertion = errorMessageConfig[assertion];
+            const defaultErrorMessage = isGlobal ? `Unexpected ${assertion}.` : `Unexpected ${assertVar}.${assertion}.`;
+            if (errorMessageConfigForAssertion) {
+                if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId && errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId) {
+                    reportErrorObject.messageId = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId : errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId;
+                } else if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage && errorMessageConfigForAssertion.unexpectedLocalAssertionMessage) {
+                    reportErrorObject.message = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage : errorMessageConfigForAssertion.unexpectedLocalAssertionMessage;
+                } else {
+                    reportErrorObject.message = defaultErrorMessage;
+                }
+            } else {
+                reportErrorObject.message = defaultErrorMessage;
+            }
+
+            context.report(reportErrorObject);
         }
 
         return {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -289,17 +289,12 @@ exports.createAssertionCheck = function (assertions, errorMessageConfig) {
                 }
             };
             const errorMessageConfigForAssertion = errorMessageConfig[assertion];
-            const defaultErrorMessage = isGlobal ? `Unexpected ${assertion}.` : `Unexpected ${assertVar}.${assertion}.`;
             if (errorMessageConfigForAssertion) {
                 if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId && errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId) {
                     reportErrorObject.messageId = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId : errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId;
                 } else if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage && errorMessageConfigForAssertion.unexpectedLocalAssertionMessage) {
                     reportErrorObject.message = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage : errorMessageConfigForAssertion.unexpectedLocalAssertionMessage;
-                } else {
-                    reportErrorObject.message = defaultErrorMessage;
                 }
-            } else {
-                reportErrorObject.message = defaultErrorMessage;
             }
 
             context.report(reportErrorObject);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -289,14 +289,10 @@ exports.createAssertionCheck = function (assertions, errorMessageConfig) {
                 }
             };
             const errorMessageConfigForAssertion = errorMessageConfig[assertion];
-            /* istanbul ignore else: correctly does nothing */
-            if (errorMessageConfigForAssertion) {
-                /* istanbul ignore else: correctly does nothing */
-                if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId && errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId) {
-                    reportErrorObject.messageId = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId : errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId;
-                } else if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage && errorMessageConfigForAssertion.unexpectedLocalAssertionMessage) {
-                    reportErrorObject.message = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage : errorMessageConfigForAssertion.unexpectedLocalAssertionMessage;
-                }
+            if (errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId && errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId) {
+                reportErrorObject.messageId = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessageId : errorMessageConfigForAssertion.unexpectedLocalAssertionMessageId;
+            } else {
+                reportErrorObject.message = isGlobal ? errorMessageConfigForAssertion.unexpectedGlobalAssertionMessage : errorMessageConfigForAssertion.unexpectedLocalAssertionMessage;
             }
 
             context.report(reportErrorObject);

--- a/tests/lib/rules/no-loose-assertions.js
+++ b/tests/lib/rules/no-loose-assertions.js
@@ -272,8 +272,11 @@ ruleTester.run("no-loose-assertions", rule, {
                           equal(a, b);
                       });
                   `,
+
+            // Extra "equal" and "ok" definitions to make sure they are properly ignored while parsing options
             options: [["ok", { disallowed: "equal",
-                recommended: ["ab"] }, "equal"]],
+                recommended: ["ab"] }, "equal", { disallowed: "ok",
+                recommended: ["ab"] }]],
             errors: [{
                 messageId: "unexpectedGlobalLooseAssertion",
                 data: { assertion: "ok" }

--- a/tests/lib/rules/no-loose-assertions.js
+++ b/tests/lib/rules/no-loose-assertions.js
@@ -215,7 +215,8 @@ ruleTester.run("no-loose-assertions", rule, {
                           assert.equal(a, b);
                       });
                   `,
-            options: [["ok", "equal"]],
+            options: [["ok", { disallowed: "equal",
+                recommended: ["ab"] }]],
             errors: [{
                 messageId: "unexpectedLocalLooseAssertion",
                 data: {
@@ -223,11 +224,7 @@ ruleTester.run("no-loose-assertions", rule, {
                     assertion: "ok"
                 }
             }, {
-                messageId: "unexpectedLocalLooseAssertion",
-                data: {
-                    assertVar: "assert",
-                    assertion: "equal"
-                }
+                message: "Unexpected assert.equal. Use assert.ab."
             }]
         },
         {
@@ -238,7 +235,8 @@ ruleTester.run("no-loose-assertions", rule, {
                           foo.equal(a, b);
                       });
                   `,
-            options: [["ok", "equal"]],
+            options: [["ok", { disallowed: "equal",
+                recommended: ["ab"] }]],
             errors: [{
                 messageId: "unexpectedLocalLooseAssertion",
                 data: {
@@ -246,11 +244,7 @@ ruleTester.run("no-loose-assertions", rule, {
                     assertion: "ok"
                 }
             }, {
-                messageId: "unexpectedLocalLooseAssertion",
-                data: {
-                    assertVar: "foo",
-                    assertion: "equal"
-                }
+                message: "Unexpected foo.equal. Use foo.ab."
             }]
         },
         {
@@ -268,6 +262,23 @@ ruleTester.run("no-loose-assertions", rule, {
             }, {
                 messageId: "unexpectedGlobalLooseAssertion",
                 data: { assertion: "equal" }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function () {
+                          ok(a, b);
+                          notOk(a, b);
+                          equal(a, b);
+                      });
+                  `,
+            options: [["ok", { disallowed: "equal",
+                recommended: ["ab"] }, "equal"]],
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "ok" }
+            }, {
+                message: "Unexpected equal. Use ab."
             }]
         }
     ]

--- a/tests/lib/rules/no-loose-assertions.js
+++ b/tests/lib/rules/no-loose-assertions.js
@@ -1,0 +1,274 @@
+/**
+ * @fileoverview Forbid the use of assert.equal/assert.ok/notOk and suggest other assertions.
+ * @author ventuno
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-loose-assertions"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-loose-assertions", rule, {
+    valid: [
+        "QUnit.test('Name', function (assert) { assert.strictEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { assert.propEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.strictEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.deepEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.propEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { strictEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { deepEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { propEqual(a, b); });",
+        "QUnit.test('Name', function () { strictEqual(a, b); });",
+        "QUnit.test('Name', function () { deepEqual(a, b); });",
+        "QUnit.test('Name', function () { propEqual(a, b); });",
+
+        // equal is not within test context
+        "equal(a, b);"
+    ],
+
+    invalid: [
+        {
+            code: "QUnit.test('Name', function (assert) { assert.ok(a); });",
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "ok"
+                }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (foo) { foo.ok(a); });",
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "ok"
+                }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.notOk(a); });",
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "notOk"
+                }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (foo) { foo.notOk(a); });",
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "notOk"
+                }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { ok(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "ok" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { notOk(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "notOk" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function () { ok(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "ok" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function () { notOk(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "notOk" }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(a, b); });",
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "equal"
+                }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (foo) { foo.equal(a, b); });",
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "equal"
+                }
+            }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { equal(a, b); });",
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "equal" }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function (assert) {
+                          assert.ok(a, b);
+                          assert.notOk(a, b);
+                          assert.equal(a, b);
+                      });
+                  `,
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "ok"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "notOk"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "equal"
+                }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function (foo) {
+                          foo.ok(a, b);
+                          foo.notOk(a, b);
+                          foo.equal(a, b);
+                      });
+                  `,
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "ok"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "notOk"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "equal"
+                }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function () {
+                          ok(a, b);
+                          notOk(a, b);
+                          equal(a, b);
+                      });
+                  `,
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "ok" }
+            }, {
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "notOk" }
+            }, {
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "equal" }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function (assert) {
+                          assert.ok(a, b);
+                          assert.notOk(a, b);
+                          assert.equal(a, b);
+                      });
+                  `,
+            options: [["ok", "equal"]],
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "ok"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "equal"
+                }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function (foo) {
+                          foo.ok(a, b);
+                          foo.notOk(a, b);
+                          foo.equal(a, b);
+                      });
+                  `,
+            options: [["ok", "equal"]],
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "ok"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "equal"
+                }
+            }]
+        },
+        {
+            code: `
+                      QUnit.test('Name', function () {
+                          ok(a, b);
+                          notOk(a, b);
+                          equal(a, b);
+                      });
+                  `,
+            options: [["ok", "equal"]],
+            errors: [{
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "ok" }
+            }, {
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "equal" }
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/no-loose-assertions.js
+++ b/tests/lib/rules/no-loose-assertions.js
@@ -138,6 +138,7 @@ ruleTester.run("no-loose-assertions", rule, {
                           assert.ok(a, b);
                           assert.notOk(a, b);
                           assert.equal(a, b);
+                          assert.notEqual(a, b);
                       });
                   `,
             errors: [{
@@ -157,6 +158,12 @@ ruleTester.run("no-loose-assertions", rule, {
                 data: {
                     assertVar: "assert",
                     assertion: "equal"
+                }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "notEqual"
                 }
             }]
         },
@@ -166,6 +173,7 @@ ruleTester.run("no-loose-assertions", rule, {
                           foo.ok(a, b);
                           foo.notOk(a, b);
                           foo.equal(a, b);
+                          foo.notEqual(a, b);
                       });
                   `,
             errors: [{
@@ -186,6 +194,12 @@ ruleTester.run("no-loose-assertions", rule, {
                     assertVar: "foo",
                     assertion: "equal"
                 }
+            }, {
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "foo",
+                    assertion: "notEqual"
+                }
             }]
         },
         {
@@ -194,6 +208,7 @@ ruleTester.run("no-loose-assertions", rule, {
                           ok(a, b);
                           notOk(a, b);
                           equal(a, b);
+                          notEqual(a, b);
                       });
                   `,
             errors: [{
@@ -205,6 +220,9 @@ ruleTester.run("no-loose-assertions", rule, {
             }, {
                 messageId: "unexpectedGlobalLooseAssertion",
                 data: { assertion: "equal" }
+            }, {
+                messageId: "unexpectedGlobalLooseAssertion",
+                data: { assertion: "notEqual" }
             }]
         },
         {

--- a/tests/lib/rules/no-loose-assertions.js
+++ b/tests/lib/rules/no-loose-assertions.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Forbid the use of assert.equal/assert.ok/notOk and suggest other assertions.
+ * @fileoverview Forbid the use of assert.equal/assert.notEqual/assert.ok/notOk and suggest other assertions.
  * @author ventuno
  */
 "use strict";


### PR DESCRIPTION
As discussed in https://github.com/platinumazure/eslint-plugin-qunit/issues/77#issuecomment-589258915 and https://github.com/platinumazure/eslint-plugin-qunit/pull/78#issue-378429556 introducing the new `no-loose-assertions` rule which allows forbids the usage of assertions like `equal`, `ok`, `notOk`.
This rule is supposed to replace [`no-assert-equal`](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md) and [`no-assert-ok`](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-ok.md) with one configurable rule.

@platinumazure please take a look and let me know what you think!