### PR TITLE
New rule: no-skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Below is the list of rules available in this plugin.
 * [no-reassign-log-callbacks](docs/rules/no-reassign-log-callbacks.md)
 * [no-reset](docs/rules/no-reset.md)
 * [no-setup-teardown](docs/rules/no-setup-teardown.md)
+* [no-skip](docs/rules/no-skip.md)
 * [no-test-expect-argument](docs/rules/no-test-expect-argument.md)
 * [no-throws-string](docs/rules/no-throws-string.md)
 * [require-expect](docs/rules/require-expect.md)

--- a/docs/rules/no-skip.md
+++ b/docs/rules/no-skip.md
@@ -1,0 +1,41 @@
+# Forbid the use of QUnit.skip (no-skip)
+
+`QUnit.skip` is useful to mark a test as skipped. This should be preferred over commenting out the test. However, leaving tests skipped in perpetuity is a bad practice, as the test ceases to provide any use in ensuring correctness of your code. Skipping tests should be done sparingly.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+
+QUnit.module.skip('Name', function() { });
+
+QUnit.skip('Name', function() { });
+
+module.skip('Name', function() { });
+
+skip('Name', function() { });
+
+```
+
+The following patterns are not considered warnings:
+
+```js
+
+QUnit.module.test('Name', function() { });
+
+QUnit.test('Name', function() { });
+
+module.test('Name', function() { });
+
+test('Name', function() { });
+
+```
+
+## When Not to Use It
+
+If your development pipeline would make running this rule annoying, it could be safely disabled. However, it would be a good idea to ensure that this rule is run in continuous integration at the very least.
+
+## Further Reading
+
+* [QUnit.skip](https://api.qunitjs.com/QUnit.skip/)

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = {
         "no-reassign-log-callbacks": require("./lib/rules/no-reassign-log-callbacks"),
         "no-reset": require("./lib/rules/no-reset"),
         "no-setup-teardown": require("./lib/rules/no-setup-teardown"),
+        "no-skip": require("./lib/rules/no-skip"),
         "no-test-expect-argument": require("./lib/rules/no-test-expect-argument"),
         "no-throws-string": require("./lib/rules/no-throws-string"),
         "require-expect": require("./lib/rules/require-expect"),

--- a/lib/rules/no-skip.js
+++ b/lib/rules/no-skip.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Forbid the use of QUnit.skip
+ * @author Steve Calvert
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "forbid QUnit.skip",
+            category: "Best Practices",
+            recommended: false
+        },
+        messages: {
+            noQUnitSkip: "Unexpected skip() call."
+        },
+        schema: []
+    },
+
+    create: function (context) {
+        return {
+            "CallExpression": function (node) {
+                if (utils.isSkip(node.callee)) {
+                    context.report({
+                        node: node,
+                        messageId: "noQUnitSkip",
+                        data: {
+                            callee: node.callee.name
+                        }
+                    });
+                }
+            }
+        };
+    }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,25 +174,33 @@ exports.isAsyncTest = function (calleeNode) {
     return result;
 };
 
-exports.isOnly = function (calleeNode) {
+function isQUnitMethod(calleeNode, qunitMethod) {
     let result = false;
 
     /* istanbul ignore else: will correctly return false */
     if (calleeNode.type === "Identifier") {
-        // only()
-        result = calleeNode.name === "only";
-    } else if (calleeNode.type === "MemberExpression" && calleeNode.property.type === "Identifier" && calleeNode.property.name === "only") {
+        // <qunitMethod>()
+        result = calleeNode.name === qunitMethod;
+    } else if (calleeNode.type === "MemberExpression" && calleeNode.property.type === "Identifier" && calleeNode.property.name === qunitMethod) {
         if (calleeNode.object.type === "Identifier") {
-            // QUnit.only() or module.only()
+            // QUnit.<qunitMethod>() or module.<qunitMethod>()
             result = calleeNode.object.name === "QUnit" || calleeNode.object.name === "module";
         } else if (calleeNode.object.type === "MemberExpression") {
-            // QUnit.*.only()
+            // QUnit.*.<qunitMethod>()
             result = calleeNode.object.object.type === "Identifier" &&
                 calleeNode.object.object.name === "QUnit";
         }
     }
 
     return result;
+}
+
+exports.isOnly = function (calleeNode) {
+    return isQUnitMethod(calleeNode, "only");
+};
+
+exports.isSkip = function (calleeNode) {
+    return isQUnitMethod(calleeNode, "skip");
 };
 
 exports.getAssertContextNameForTest = function (argumentsNodes) {

--- a/tests/lib/rules/no-skip.js
+++ b/tests/lib/rules/no-skip.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Forbid the use of QUnit.skip
+ * @author Steve Calvert
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-skip"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+function createError(callee) {
+    return {
+        messageId: "noQUnitSkip",
+        data: {
+            callee
+        }
+    };
+}
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-skip", rule, {
+    valid: [
+        "QUnit.module.test('Name', function() { });",
+        "QUnit.test('Name', function() { });",
+        "module.test('Name', function() { });",
+        "test('Name', function() { });"
+    ],
+
+    invalid: [
+        {
+            code: "QUnit.module.skip('Name', function() { });",
+            errors: [createError("QUnit.module.skip")]
+        },
+        {
+            code: "QUnit.skip('Name', function() { });",
+            errors: [createError("QUnit.skip")]
+        },
+        {
+            code: "module.skip('Name', function() { });",
+            errors: [createError("module.skip")]
+        },
+        {
+            code: "skip('Name', function() { });",
+            errors: [createError("skip")]
+        }
+    ]
+});


### PR DESCRIPTION
Similar to `no-only` (and largely copied from), this rule prevents the use of `skip` in tests. As noted in the readme:

> `QUnit.skip` is useful to mark a test as skipped. This should be preferred over commenting out the test. However, leaving tests skipped in perpetuity is a bad practice, as the test ceases to provide any use in ensuring correctness of your code. Skipping tests should be done sparingly.

It's debatable whether this should be part of recommended or not. I'm open to discussions.