### PR TITLE
Add a fixer for no-arrow-tests

### DIFF
--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -22,6 +22,7 @@ module.exports = {
             description: "forbid arrow functions as QUnit test/module callbacks",
             category: "Best Practices"
         },
+        fixable: "code",
         messages: {
             noArrowFunction: "Arrow function should not be used as test callback."
         },
@@ -33,11 +34,33 @@ module.exports = {
         // Helpers
         //--------------------------------------------------------------------------
 
-        function checkCallback(testCallbackNode) {
-            if (testCallbackNode && testCallbackNode.type === "ArrowFunctionExpression") {
+        // Fixer adapted from https://github.com/lo1tuma/eslint-plugin-mocha (MIT)
+        const sourceCode = context.getSourceCode();
+
+        function formatFunctionHead(fn) {
+            const paramsLeftParen = sourceCode.getFirstToken(fn);
+            const paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fn.body));
+            let paramsFullText = sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]);
+            const functionKeyword = "function";
+
+            if (fn.params.length > 0) {
+                paramsFullText = `(${sourceCode.text.slice(fn.params[0].range[0], fn.params[fn.params.length - 1].range[1])})`;
+            }
+
+            return `${functionKeyword}${paramsFullText} `;
+        }
+
+        function checkCallback(fn) {
+            if (fn && fn.type === "ArrowFunctionExpression") {
                 context.report({
-                    node: testCallbackNode,
-                    messageId: "noArrowFunction"
+                    node: fn,
+                    messageId: "noArrowFunction",
+                    fix: function (fixer) {
+                        return fixer.replaceTextRange(
+                            [fn.range[0], fn.body.range[0]],
+                            formatFunctionHead(fn)
+                        );
+                    }
                 });
             }
         }

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -37,16 +37,17 @@ module.exports = {
         // Fixer adapted from https://github.com/lo1tuma/eslint-plugin-mocha (MIT)
         const sourceCode = context.getSourceCode();
 
+        function extractSourceTextByRange(start, end) {
+            return sourceCode.text.slice(start, end).trim();
+        }
+
         function formatFunctionHead(fn) {
             const arrow = sourceCode.getTokenBefore(fn.body);
-            let firstToken = sourceCode.getFirstToken(fn);
             const beforeArrowToken = sourceCode.getTokenBefore(arrow);
-            let paramsFullText;
-            let params = sourceCode.text.slice(firstToken.range[0], beforeArrowToken.range[1]).trim();
-            let functionKeyword = "function";
-            const beforeArrowComment = sourceCode.text.slice(beforeArrowToken.range[1], arrow.range[0]).trim();
-            const afterArrowComment = sourceCode.text.slice(arrow.range[1], fn.body.range[0]).trim();
+            let firstToken = sourceCode.getFirstToken(fn);
 
+            let functionKeyword = "function";
+            let params = extractSourceTextByRange(firstToken.range[0], beforeArrowToken.range[1]);
             if (fn.async) {
                 // When 'async' specified strip the token from the params text
                 // and prepend it to the function keyword
@@ -57,6 +58,9 @@ module.exports = {
                 firstToken = sourceCode.getTokenAfter(firstToken);
             }
 
+            const beforeArrowComment = extractSourceTextByRange(beforeArrowToken.range[1], arrow.range[0]);
+            const afterArrowComment = extractSourceTextByRange(arrow.range[1], fn.body.range[0]);
+            let paramsFullText;
             if (firstToken.type !== "Punctuator") {
                 paramsFullText = `(${params}${beforeArrowComment})${afterArrowComment}`;
             } else {

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -42,7 +42,7 @@ module.exports = {
             let firstToken = sourceCode.getFirstToken(fn);
             const beforeArrowToken = sourceCode.getTokenBefore(arrow);
             let paramsFullText;
-            let params = sourceCode.text.slice(firstToken.range[0], beforeArrowToken.range[1]);
+            let params = sourceCode.text.slice(firstToken.range[0], beforeArrowToken.range[1]).trim();
             let functionKeyword = "function";
             const beforeArrowComment = sourceCode.text.slice(beforeArrowToken.range[1], arrow.range[0]).trim();
             const afterArrowComment = sourceCode.text.slice(arrow.range[1], fn.body.range[0]).trim();
@@ -50,7 +50,7 @@ module.exports = {
             if (fn.async) {
                 // When 'async' specified strip the token from the params text
                 // and prepend it to the function keyword
-                params = params.slice(firstToken.range[1] - firstToken.range[0]);
+                params = params.slice(firstToken.range[1] - firstToken.range[0]).trim();
                 functionKeyword = "async function";
 
                 // Advance firstToken pointer

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -38,22 +38,49 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         function formatFunctionHead(fn) {
-            const paramsLeftParen = sourceCode.getFirstToken(fn);
             const arrow = sourceCode.getTokenBefore(fn.body);
-            const paramsRightParen = sourceCode.getTokenBefore(arrow);
+            let firstToken = sourceCode.getFirstToken(fn);
+            const beforeArrowToken = sourceCode.getTokenBefore(arrow);
             let paramsFullText;
-            const params = sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]);
-            const functionKeyword = "function";
-            const commentBeforeArrow = sourceCode.text.slice(paramsRightParen.range[1], arrow.range[0]).trim();
-            const commentAfterArrow = sourceCode.text.slice(arrow.range[1], fn.body.range[0]).trim();
+            let params = sourceCode.text.slice(firstToken.range[0], beforeArrowToken.range[1]);
+            let functionKeyword = "function";
+            const beforeArrowComment = sourceCode.text.slice(beforeArrowToken.range[1], arrow.range[0]).trim();
+            const afterArrowComment = sourceCode.text.slice(arrow.range[1], fn.body.range[0]).trim();
 
-            if (paramsLeftParen.type !== "Punctuator") {
-                paramsFullText = `(${params}${commentBeforeArrow})${commentAfterArrow}`;
+            if (fn.async) {
+                // When 'async' specified strip the token from the params text
+                // and prepend it to the function keyword
+                params = params.slice(firstToken.range[1] - firstToken.range[0]);
+                functionKeyword = "async function";
+
+                // Advance firstToken pointer
+                firstToken = sourceCode.getTokenAfter(firstToken);
+            }
+
+            if (firstToken.type !== "Punctuator") {
+                paramsFullText = `(${params}${beforeArrowComment})${afterArrowComment}`;
             } else {
-                paramsFullText = `${params}${commentBeforeArrow}${commentAfterArrow}`;
+                paramsFullText = `${params}${beforeArrowComment}${afterArrowComment}`;
             }
 
             return `${functionKeyword}${paramsFullText} `;
+        }
+
+        function fixArrowFunction(fixer, fn) {
+            if (fn.body.type === "BlockStatement") {
+                // When it((...) => { ... }),
+                // simply replace '(...) => ' with 'function () '
+                return fixer.replaceTextRange(
+                    [fn.range[0], fn.body.range[0]],
+                    formatFunctionHead(fn)
+                );
+            }
+
+            const bodyText = sourceCode.text.slice(fn.body.range[0], fn.body.range[1]);
+            return fixer.replaceTextRange(
+                [fn.range[0], fn.range[1]],
+                `${formatFunctionHead(fn)}{ return ${bodyText}; }`
+            );
         }
 
         function checkCallback(fn) {
@@ -61,12 +88,7 @@ module.exports = {
                 context.report({
                     node: fn,
                     messageId: "noArrowFunction",
-                    fix: function (fixer) {
-                        return fixer.replaceTextRange(
-                            [fn.range[0], fn.body.range[0]],
-                            formatFunctionHead(fn)
-                        );
-                    }
+                    fix: fixer => fixArrowFunction(fixer, fn)
                 });
             }
         }

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -39,12 +39,18 @@ module.exports = {
 
         function formatFunctionHead(fn) {
             const paramsLeftParen = sourceCode.getFirstToken(fn);
-            const paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fn.body));
-            let paramsFullText = sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]);
+            const arrow = sourceCode.getTokenBefore(fn.body);
+            const paramsRightParen = sourceCode.getTokenBefore(arrow);
+            let paramsFullText;
+            const params = sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]);
             const functionKeyword = "function";
+            const commentBeforeArrow = sourceCode.text.slice(paramsRightParen.range[1], arrow.range[0]).trim();
+            const commentAfterArrow = sourceCode.text.slice(arrow.range[1], fn.body.range[0]).trim();
 
-            if (fn.params.length > 0) {
-                paramsFullText = `(${sourceCode.text.slice(fn.params[0].range[0], fn.params[fn.params.length - 1].range[1])})`;
+            if (paramsLeftParen.type !== "Punctuator") {
+                paramsFullText = `(${params}${commentBeforeArrow})${commentAfterArrow}`;
+            } else {
+                paramsFullText = `${params}${commentBeforeArrow}${commentAfterArrow}`;
             }
 
             return `${functionKeyword}${paramsFullText} `;

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -19,7 +19,7 @@ const rule = require("../../../lib/rules/no-arrow-tests"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-    parserOptions: { ecmaVersion: 6 }
+    parserOptions: { ecmaVersion: 2017 }
 });
 ruleTester.run("no-arrow-tests", rule, {
 
@@ -182,6 +182,26 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "module('module', { afterEach: () => {} });",
             output: "module('module', { afterEach: function() {} });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+
+        // No function body
+        {
+            code: "QUnit.test('test', () => ok(true));",
+            output: "QUnit.test('test', function() { return ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+
+        // Async function
+        {
+            code: "QUnit.test('test', async () => { assert.ok(false) })",
+            output: "QUnit.test('test', async function () { assert.ok(false) })",
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -186,6 +186,34 @@ ruleTester.run("no-arrow-tests", rule, {
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
             }]
+        },
+
+        // Comment placement
+        {
+            code: "QUnit.test('a test', /* comment */ assert => { assert.ok(true); });",
+            output: "QUnit.test('a test', /* comment */ function(assert) { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+
+        // Unsupported comment placement
+        {
+            code: "QUnit.test('a test', assert /* comment */ => { assert.ok(true); });",
+            output: "QUnit.test('a test', function(assert) { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "QUnit.test('a test', (assert /* comment */) => { assert.ok(true); });",
+            output: "QUnit.test('a test', function(assert) { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -201,7 +201,7 @@ ruleTester.run("no-arrow-tests", rule, {
         // Async function
         {
             code: "QUnit.test('test', async () => { assert.ok(false) })",
-            output: "QUnit.test('test', async function () { assert.ok(false) })",
+            output: "QUnit.test('test', async function() { assert.ok(false) })",
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -229,8 +229,6 @@ ruleTester.run("no-arrow-tests", rule, {
                 type: "ArrowFunctionExpression"
             }]
         },
-
-        // Unsupported comment placement
         {
             code: "QUnit.test('a test 6', assert /* comment */ =>\n{ assert.ok(true); }\n);",
             output: "QUnit.test('a test 6', function(assert/* comment */) { assert.ok(true); }\n);",

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -60,6 +60,7 @@ ruleTester.run("no-arrow-tests", rule, {
         // tests
         {
             code: "QUnit.test('test', (assert) => { assert.ok(true); });",
+            output: "QUnit.test('test', function(assert) { assert.ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -68,6 +69,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "QUnit.test('test', () => { ok(true); });",
+            output: "QUnit.test('test', function() { ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -76,6 +78,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "QUnit.asyncTest('test', (assert) => { assert.ok(true); });",
+            output: "QUnit.asyncTest('test', function(assert) { assert.ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -84,6 +87,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "QUnit.asyncTest('test', () => { ok(true); });",
+            output: "QUnit.asyncTest('test', function() { ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -92,6 +96,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "test('test', (assert) => { assert.ok(true); });",
+            output: "test('test', function(assert) { assert.ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -100,6 +105,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "test('test', () => { ok(true); });",
+            output: "test('test', function() { ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -108,6 +114,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "asyncTest('test', (assert) => { assert.ok(true); });",
+            output: "asyncTest('test', function(assert) { assert.ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -116,6 +123,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "asyncTest('test', () => { ok(true); });",
+            output: "asyncTest('test', function() { ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -126,6 +134,7 @@ ruleTester.run("no-arrow-tests", rule, {
         // modules
         {
             code: "QUnit.module('module', { setup: () => {} });",
+            output: "QUnit.module('module', { setup: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -134,6 +143,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "QUnit.module('module', { teardown: () => {} });",
+            output: "QUnit.module('module', { teardown: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -142,6 +152,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "QUnit.module('module', { beforeEach: () => {} });",
+            output: "QUnit.module('module', { beforeEach: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -150,6 +161,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "QUnit.module('module', { afterEach: () => {} });",
+            output: "QUnit.module('module', { afterEach: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -158,6 +170,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "module('module', { setup: () => {} });",
+            output: "module('module', { setup: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -166,6 +179,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "module('module', { teardown: () => {} });",
+            output: "module('module', { teardown: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -174,6 +188,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "module('module', { beforeEach: () => {} });",
+            output: "module('module', { beforeEach: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
@@ -182,6 +197,7 @@ ruleTester.run("no-arrow-tests", rule, {
         },
         {
             code: "module('module', { afterEach: () => {} });",
+            output: "module('module', { afterEach: function() {} });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -18,7 +18,9 @@ const rule = require("../../../lib/rules/no-arrow-tests"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+    parserOptions: { ecmaVersion: 6 }
+});
 ruleTester.run("no-arrow-tests", rule, {
 
     valid: [
@@ -43,17 +45,14 @@ ruleTester.run("no-arrow-tests", rule, {
         "module('module', { afterEach: function () {} });",
 
         // not actually module hooks
-        {
-            code: [
-                "var a = {",
-                "    setup: () => {},",
-                "    teardown: () => {},",
-                "    beforeEach: () => {},",
-                "    afterEach: () => {}",
-                "};"
-            ].join("\n"),
-            parserOptions: { ecmaVersion: 6 }
-        }
+        [
+            "var a = {",
+            "    setup: () => {},",
+            "    teardown: () => {},",
+            "    beforeEach: () => {},",
+            "    afterEach: () => {}",
+            "};"
+        ].join("\n")
     ],
 
     invalid: [
@@ -61,7 +60,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.test('test', (assert) => { assert.ok(true); });",
             output: "QUnit.test('test', function(assert) { assert.ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -70,7 +68,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.test('test', () => { ok(true); });",
             output: "QUnit.test('test', function() { ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -79,7 +76,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.asyncTest('test', (assert) => { assert.ok(true); });",
             output: "QUnit.asyncTest('test', function(assert) { assert.ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -88,7 +84,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.asyncTest('test', () => { ok(true); });",
             output: "QUnit.asyncTest('test', function() { ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -97,7 +92,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "test('test', (assert) => { assert.ok(true); });",
             output: "test('test', function(assert) { assert.ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -106,7 +100,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "test('test', () => { ok(true); });",
             output: "test('test', function() { ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -115,7 +108,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "asyncTest('test', (assert) => { assert.ok(true); });",
             output: "asyncTest('test', function(assert) { assert.ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -124,7 +116,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "asyncTest('test', () => { ok(true); });",
             output: "asyncTest('test', function() { ok(true); });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -135,7 +126,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.module('module', { setup: () => {} });",
             output: "QUnit.module('module', { setup: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -144,7 +134,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.module('module', { teardown: () => {} });",
             output: "QUnit.module('module', { teardown: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -153,7 +142,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.module('module', { beforeEach: () => {} });",
             output: "QUnit.module('module', { beforeEach: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -162,7 +150,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "QUnit.module('module', { afterEach: () => {} });",
             output: "QUnit.module('module', { afterEach: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -171,7 +158,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "module('module', { setup: () => {} });",
             output: "module('module', { setup: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -180,7 +166,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "module('module', { teardown: () => {} });",
             output: "module('module', { teardown: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -189,7 +174,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "module('module', { beforeEach: () => {} });",
             output: "module('module', { beforeEach: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -198,7 +182,6 @@ ruleTester.run("no-arrow-tests", rule, {
         {
             code: "module('module', { afterEach: () => {} });",
             output: "module('module', { afterEach: function() {} });",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -190,8 +190,40 @@ ruleTester.run("no-arrow-tests", rule, {
 
         // Comment placement
         {
-            code: "QUnit.test('a test', /* comment */ assert => { assert.ok(true); });",
-            output: "QUnit.test('a test', /* comment */ function(assert) { assert.ok(true); });",
+            code: "QUnit.test('a test 1', /* comment */ assert => { assert.ok(true); });",
+            output: "QUnit.test('a test 1', /* comment */ function(assert) { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "QUnit.test('a test 2', (assert /* comment */) => { assert.ok(true); });",
+            output: "QUnit.test('a test 2', function(assert /* comment */) { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "QUnit.test('a test 3', (assert) /* comment */ => { assert.ok(true); });",
+            output: "QUnit.test('a test 3', function(assert)/* comment */ { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "QUnit.test('a test 4', (assert) => /* comment */ { assert.ok(true); });",
+            output: "QUnit.test('a test 4', function(assert)/* comment */ { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "QUnit.test('a test 5', (/* assert */) => { noop(); });",
+            output: "QUnit.test('a test 5', function(/* assert */) { noop(); });",
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
@@ -200,16 +232,24 @@ ruleTester.run("no-arrow-tests", rule, {
 
         // Unsupported comment placement
         {
-            code: "QUnit.test('a test', assert /* comment */ => { assert.ok(true); });",
-            output: "QUnit.test('a test', function(assert) { assert.ok(true); });",
+            code: "QUnit.test('a test 6', assert /* comment */ =>\n{ assert.ok(true); }\n);",
+            output: "QUnit.test('a test 6', function(assert/* comment */) { assert.ok(true); }\n);",
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"
             }]
         },
         {
-            code: "QUnit.test('a test', (assert /* comment */) => { assert.ok(true); });",
-            output: "QUnit.test('a test', function(assert) { assert.ok(true); });",
+            code: "QUnit.test('a test 7', assert /* comment */ => { assert.ok(true); });",
+            output: "QUnit.test('a test 7', function(assert/* comment */) { assert.ok(true); });",
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "QUnit.test('a test 8', assert => /* comment */ { assert.ok(true); });",
+            output: "QUnit.test('a test 8', function(assert)/* comment */ { assert.ok(true); });",
             errors: [{
                 messageId: "noArrowFunction",
                 type: "ArrowFunctionExpression"


### PR DESCRIPTION
Fixer adapted from eslint-plugin-mocha (MIT)