### PR TITLE
New: Add "no-nested-tests" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Below is the list of rules available in this plugin.
 * [no-jsdump](docs/rules/no-jsdump.md)
 * [no-loose-assertions](docs/rules/no-loose-assertions.md)
 * [no-negated-ok](docs/rules/no-negated-ok.md)
+* [no-nested-tests](docs/rules/no-nested-tests.md)
 * [no-ok-equality](docs/rules/no-ok-equality.md)
 * [no-only](docs/rules/no-only.md)
 * [no-qunit-push](docs/rules/no-qunit-push.md)

--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -1,0 +1,46 @@
+# Forbid QUnit.test() calls inside callback of another QUnit.test (no-nested-tests)
+
+This rule prevents from incorrect usage of [Nested Scope](https://github.com/qunitjs/qunit/blob/master/docs/QUnit/module.md#nested-scope). Developer can write nested test instead of nested module by mistake. In this case test will still be executed, but effects may be unexpected.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+
+QUnit.test('Parent', function () {
+    QUnit.test('Child', function () {});
+});
+
+test('Parent', function () {
+    test('Child', function () {});
+});
+
+```
+
+The following patterns are not considered warnings:
+
+```js
+
+QUnit.test('First', function () {});
+QUnit.test('Second', function () {});
+
+QUnit.module('ParentModule', function () {
+    QUnit.test('Parent', function () {});
+
+    QUnit.module('ChildModule', function () {
+        QUnit.test('ChildTest', function () {});
+    });
+})
+
+```
+
+## When Not To Use It
+
+It should be safe to use this rule. However it may cause false positive when using same namespace `test` during act or arrange stages.
+
+## Further Reading
+
+* [QUnit.module() Nested Scope](https://github.com/qunitjs/qunit/blob/master/docs/QUnit/module.md#nested-scope)
+* [QUnit.test](https://github.com/qunitjs/qunit/blob/master/docs/QUnit/test.md)
+

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
         "no-jsdump": require("./lib/rules/no-jsdump"),
         "no-loose-assertions": require("./lib/rules/no-assert-ok"),
         "no-negated-ok": require("./lib/rules/no-negated-ok"),
+        "no-nested-tests": require("./lib/rules/no-nested-tests"),
         "no-ok-equality": require("./lib/rules/no-ok-equality"),
         "no-only": require("./lib/rules/no-only"),
         "no-qunit-push": require("./lib/rules/no-qunit-push"),

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Forbid usage of nested QUnit.test()
+ * @author Aliaksandr Yermalayeu
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Forbid nested QUnit.test() calls",
+            category: "Possible Errors"
+        },
+        messages: {
+            noNestedTests: "Usage of QUnit.test inside of another QUnit.test is not allowed."
+        },
+        schema: []
+    },
+
+    create: function (context) {
+        return {
+            "CallExpression": function (node) {
+                if (utils.isTest(node.callee)) {
+                    let currentNode = node;
+                    while (currentNode.parent) {
+                        const { parent } = currentNode;
+                        if (parent.type === "CallExpression" && utils.isTest(parent.callee)) {
+                            context.report({
+                                node,
+                                messageId: "noNestedTests"
+                            });
+                            return;
+                        }
+                        currentNode = parent;
+                    }
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-nested-tests.js
+++ b/tests/lib/rules/no-nested-tests.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Forbid usage of nested QUnit.test()
+ * @author Aliaksandr Yermalayeu
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-nested-tests"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-nested-tests", rule, {
+    valid: [
+        "QUnit.test('Name', function() { });",
+        "test('Name', function() { });",
+        "QUnit.test('First', function() { }); \n QUnit.test('Second', function() { });",
+        "test('First', function() { }); \n test('Second', function() { });",
+        "QUnit.module('ParentModule', function () {\n QUnit.test('Name', function() {});\n QUnit.module('ChildModule', function () {\n QUnit.test('ChildTest', function () {});\n });\n })\n",
+        "module('ParentModule', function () {\n test('Name', function() {});\n module('ChildModule', function () {\n test('ChildTest', function () {});\n });\n })\n"
+    ],
+
+    invalid: [
+        {
+            code: "QUnit.test('Parent', function() {\n QUnit.test('Child', function () {}); });",
+            errors: [
+                {
+                    messageId: "noNestedTests"
+                }
+            ]
+        },
+        {
+            code: "test('Parent', function() {\n test('Child', function () {}); });",
+            errors: [
+                {
+                    messageId: "noNestedTests"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
New rule to restrict usage of `Qunit.test()` inside another `QUnit.test()`

Possibly related: https://github.com/platinumazure/eslint-plugin-qunit/issues/26