### PR TITLE
Add autofixer to `literal-compare-order` rule

### DIFF
--- a/lib/rules/literal-compare-order.js
+++ b/lib/rules/literal-compare-order.js
@@ -15,12 +15,22 @@ const assert = require("assert"),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+function swapFirstTwoNodesInList(sourceCode, fixer, list) {
+    const node0Text = sourceCode.getText(list[0]);
+    const node1Text = sourceCode.getText(list[1]);
+    return [
+        fixer.replaceText(list[0], node1Text),
+        fixer.replaceText(list[1], node0Text)
+    ];
+}
+
 module.exports = {
     meta: {
         docs: {
             description: "ensure comparison assertions have arguments in the right order",
             category: "Possible Errors"
         },
+        fixable: "code",
         messages: {
             actualFirst: "Expected value {{expected}} should be specified after actual value {{actual}}.",
             expectedFirst: "Actual value {{actual}} should be specified after expected value {{expected}}."
@@ -46,6 +56,9 @@ module.exports = {
                     data: {
                         expected: sourceCode.getText(args[0]),
                         actual: sourceCode.getText(args[1])
+                    },
+                    fix(fixer) {
+                        return swapFirstTwoNodesInList(sourceCode, fixer, args);
                     }
                 });
             } else /* istanbul ignore next: no assertions compare expected first */ if (!compareActualFirst && args[0].type !== "Literal" && args[1].type === "Literal") {
@@ -55,6 +68,9 @@ module.exports = {
                     data: {
                         expected: sourceCode.getText(args[0]),
                         actual: sourceCode.getText(args[1])
+                    },
+                    fix(fixer) {
+                        return swapFirstTwoNodesInList(sourceCode, fixer, args);
                     }
                 });
             }

--- a/tests/lib/rules/literal-compare-order.js
+++ b/tests/lib/rules/literal-compare-order.js
@@ -83,6 +83,7 @@ ruleTester.run("literal-compare-order", rule, {
         // equal
         {
             code: wrap("equal('Literal', variable);"),
+            output: wrap("equal(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -93,6 +94,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("equal('Literal', variable, 'message');"),
+            output: wrap("equal(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -103,6 +105,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.equal('Literal', variable);"),
+            output: wrap("assert.equal(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -113,6 +116,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.equal('Literal', variable, 'message');"),
+            output: wrap("assert.equal(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -125,6 +129,7 @@ ruleTester.run("literal-compare-order", rule, {
         // strictEqual
         {
             code: wrap("strictEqual('Literal', variable);"),
+            output: wrap("strictEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -135,6 +140,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("strictEqual('Literal', variable, 'message');"),
+            output: wrap("strictEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -145,6 +151,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.strictEqual('Literal', variable);"),
+            output: wrap("assert.strictEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -155,6 +162,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.strictEqual('Literal', variable, 'message');"),
+            output: wrap("assert.strictEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -167,6 +175,7 @@ ruleTester.run("literal-compare-order", rule, {
         // deepEqual
         {
             code: wrap("deepEqual('Literal', variable);"),
+            output: wrap("deepEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -177,6 +186,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("deepEqual('Literal', variable, 'message');"),
+            output: wrap("deepEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -187,6 +197,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.deepEqual('Literal', variable);"),
+            output: wrap("assert.deepEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -197,6 +208,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.deepEqual('Literal', variable, 'message');"),
+            output: wrap("assert.deepEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -209,6 +221,7 @@ ruleTester.run("literal-compare-order", rule, {
         // propEqual
         {
             code: wrap("propEqual('Literal', variable);"),
+            output: wrap("propEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -219,6 +232,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("propEqual('Literal', variable, 'message');"),
+            output: wrap("propEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -229,6 +243,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.propEqual('Literal', variable);"),
+            output: wrap("assert.propEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -239,6 +254,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.propEqual('Literal', variable, 'message');"),
+            output: wrap("assert.propEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -251,6 +267,7 @@ ruleTester.run("literal-compare-order", rule, {
         // notEqual
         {
             code: wrap("notEqual('Literal', variable);"),
+            output: wrap("notEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -261,6 +278,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("notEqual('Literal', variable, 'message');"),
+            output: wrap("notEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -271,6 +289,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notEqual('Literal', variable);"),
+            output: wrap("assert.notEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -281,6 +300,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notEqual('Literal', variable, 'message');"),
+            output: wrap("assert.notEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -293,6 +313,7 @@ ruleTester.run("literal-compare-order", rule, {
         // notStrictEqual
         {
             code: wrap("notStrictEqual('Literal', variable);"),
+            output: wrap("notStrictEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -303,6 +324,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("notStrictEqual('Literal', variable, 'message');"),
+            output: wrap("notStrictEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -313,6 +335,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notStrictEqual('Literal', variable);"),
+            output: wrap("assert.notStrictEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -323,6 +346,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notStrictEqual('Literal', variable, 'message');"),
+            output: wrap("assert.notStrictEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -335,6 +359,7 @@ ruleTester.run("literal-compare-order", rule, {
         // notDeepEqual
         {
             code: wrap("notDeepEqual('Literal', variable);"),
+            output: wrap("notDeepEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -345,6 +370,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("notDeepEqual('Literal', variable, 'message');"),
+            output: wrap("notDeepEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -355,6 +381,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notDeepEqual('Literal', variable);"),
+            output: wrap("assert.notDeepEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -365,6 +392,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notDeepEqual('Literal', variable, 'message');"),
+            output: wrap("assert.notDeepEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -377,6 +405,7 @@ ruleTester.run("literal-compare-order", rule, {
         // notPropEqual
         {
             code: wrap("notPropEqual('Literal', variable);"),
+            output: wrap("notPropEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -387,6 +416,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("notPropEqual('Literal', variable, 'message');"),
+            output: wrap("notPropEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -397,6 +427,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notPropEqual('Literal', variable);"),
+            output: wrap("assert.notPropEqual(variable, 'Literal');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {
@@ -407,6 +438,7 @@ ruleTester.run("literal-compare-order", rule, {
         },
         {
             code: wrap("assert.notPropEqual('Literal', variable, 'message');"),
+            output: wrap("assert.notPropEqual(variable, 'Literal', 'message');"),
             errors: [{
                 messageId: "actualFirst",
                 data: {


### PR DESCRIPTION
This makes it much easier to adopt this rule. Changing the order of arguments does not cause any behavior change.