### PR TITLE
Add autofixer to `no-ok-equality` rule

### DIFF
--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -16,6 +16,7 @@ module.exports = {
             description: "forbid equality comparisons in assert.ok/assert.notOk",
             category: "Best Practices"
         },
+        fixable: "code",
         messages: {
             noEqualityCheckInOk: "Unexpected equality comparison in {{assertion}} call. Use {{suggestion}}({{a}}, {{b}}) instead."
         },
@@ -127,18 +128,29 @@ module.exports = {
                     isArgStrictEqual = isStrict(firstArg),
                     isArgNegative = isNegative(firstArg);
 
+                const suggestion = getSuggestedAssertion({
+                    strict: isArgStrictEqual,
+                    negative: isArgNegative !== isCalleeNegative
+                });
+
+                const a = sourceCode.getText(firstArg.left);
+                const b = sourceCode.getText(firstArg.right);
+
                 if (isArgEqual) {
                     context.report({
                         node: node,
                         messageId: "noEqualityCheckInOk",
                         data: {
                             assertion: sourceCode.getText(node.callee),
-                            suggestion: getSuggestedAssertion({
-                                strict: isArgStrictEqual,
-                                negative: isArgNegative !== isCalleeNegative
-                            }),
-                            a: sourceCode.getText(firstArg.left),
-                            b: sourceCode.getText(firstArg.right)
+                            suggestion,
+                            a,
+                            b
+                        },
+                        fix(fixer) {
+                            const newArgs = [
+                                a, b, ...args.slice(1).map(arg => sourceCode.getText(arg))
+                            ];
+                            return fixer.replaceText(node, `${suggestion}(${newArgs.join(", ")})`);
                         }
                     });
                 }

--- a/tests/lib/rules/no-ok-equality.js
+++ b/tests/lib/rules/no-ok-equality.js
@@ -85,18 +85,29 @@ ruleTester.run("no-ok-equality", rule, {
     invalid: [
         {
             code: "test('Name', function (assert) { assert.ok(x === 1); });",
+            output: "test('Name', function (assert) { assert.strictEqual(x, 1); });",
+            errors: [
+                createError("assert.ok", "assert.strictEqual", "x", "1")
+            ]
+        },
+        {
+            // With message:
+            code: "test('Name', function (assert) { assert.ok(x === 1, 'my message'); });",
+            output: "test('Name', function (assert) { assert.strictEqual(x, 1, 'my message'); });",
             errors: [
                 createError("assert.ok", "assert.strictEqual", "x", "1")
             ]
         },
         {
             code: "test('Name', function (assert) { assert.notOk(x === 1); });",
+            output: "test('Name', function (assert) { assert.notStrictEqual(x, 1); });",
             errors: [
                 createError("assert.notOk", "assert.notStrictEqual", "x", "1")
             ]
         },
         {
             code: "test('Name', function () { ok(x === 1); });",
+            output: "test('Name', function () { strictEqual(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("ok", "strictEqual", "x", "1")
@@ -104,6 +115,7 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function () { notOk(x === 1); });",
+            output: "test('Name', function () { notStrictEqual(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("notOk", "notStrictEqual", "x", "1")
@@ -111,18 +123,21 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function (assert) { assert.ok(x == 1); });",
+            output: "test('Name', function (assert) { assert.equal(x, 1); });",
             errors: [
                 createError("assert.ok", "assert.equal", "x", "1")
             ]
         },
         {
             code: "test('Name', function (assert) { assert.notOk(x == 1); });",
+            output: "test('Name', function (assert) { assert.notEqual(x, 1); });",
             errors: [
                 createError("assert.notOk", "assert.notEqual", "x", "1")
             ]
         },
         {
             code: "test('Name', function () { ok(x == 1); });",
+            output: "test('Name', function () { equal(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("ok", "equal", "x", "1")
@@ -130,6 +145,7 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function () { notOk(x == 1); });",
+            output: "test('Name', function () { notEqual(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("notOk", "notEqual", "x", "1")
@@ -137,18 +153,21 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function (assert) { assert.ok(x !== 1); });",
+            output: "test('Name', function (assert) { assert.notStrictEqual(x, 1); });",
             errors: [
                 createError("assert.ok", "assert.notStrictEqual", "x", "1")
             ]
         },
         {
             code: "test('Name', function (assert) { assert.notOk(x !== 1); });",
+            output: "test('Name', function (assert) { assert.strictEqual(x, 1); });",
             errors: [
                 createError("assert.notOk", "assert.strictEqual", "x", "1")
             ]
         },
         {
             code: "test('Name', function () { ok(x !== 1); });",
+            output: "test('Name', function () { notStrictEqual(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("ok", "notStrictEqual", "x", "1")
@@ -156,6 +175,7 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function () { notOk(x !== 1); });",
+            output: "test('Name', function () { strictEqual(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("notOk", "strictEqual", "x", "1")
@@ -163,18 +183,21 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function (assert) { assert.ok(x != 1); });",
+            output: "test('Name', function (assert) { assert.notEqual(x, 1); });",
             errors: [
                 createError("assert.ok", "assert.notEqual", "x", "1")
             ]
         },
         {
             code: "test('Name', function (assert) { assert.notOk(x != 1); });",
+            output: "test('Name', function (assert) { assert.equal(x, 1); });",
             errors: [
                 createError("assert.notOk", "assert.equal", "x", "1")
             ]
         },
         {
             code: "test('Name', function () { ok(x != 1); });",
+            output: "test('Name', function () { notEqual(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("ok", "notEqual", "x", "1")
@@ -182,6 +205,7 @@ ruleTester.run("no-ok-equality", rule, {
         },
         {
             code: "test('Name', function () { notOk(x != 1); });",
+            output: "test('Name', function () { equal(x, 1); });",
             options: [{ allowGlobal: true }],
             errors: [
                 createError("notOk", "equal", "x", "1")


### PR DESCRIPTION
I used this on my codebase to fix 100+ violations.