### PR TITLE
Fix `no-compare-relation-boolean` rule to handle assertions with messages

### DIFF
--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -66,10 +66,10 @@ module.exports = {
         function checkAssertArguments(callExprNode) {
             const args = callExprNode.arguments.slice();
 
-            args.sort(sortLiteralFirst);
+            const firstTwoArgsSorted = args.slice(0, 2).sort(sortLiteralFirst);
 
-            if (args[0].type === "Literal" && args[1].type === "BinaryExpression") {
-                checkAndReport(callExprNode, args[0], args[1]);
+            if (firstTwoArgsSorted[0].type === "Literal" && firstTwoArgsSorted[1].type === "BinaryExpression") {
+                checkAndReport(callExprNode, firstTwoArgsSorted[0], firstTwoArgsSorted[1]);
             }
         }
 

--- a/tests/lib/rules/no-compare-relation-boolean.js
+++ b/tests/lib/rules/no-compare-relation-boolean.js
@@ -55,6 +55,8 @@ ruleTester.run("no-compare-relation-boolean", rule, {
     invalid: [
         "assert.equal(a === b, true);",
         "assert.equal(a === b, false);",
+        "assert.equal(a === b, true, 'message');", // With message
+        "assert.equal(a === b, false, 'message');", // With message
 
         "assert.strictEqual(a === b, true);",
         "assert.strictEqual(a === b, false);",
@@ -80,6 +82,8 @@ ruleTester.run("no-compare-relation-boolean", rule, {
         // Argument order does not matter for this rule
         "assert.equal(true, a === b);",
         "assert.equal(false, a === b);",
+        "assert.equal(true, a === b, 'message');", // With message
+        "assert.equal(false, a === b, 'message');", // With message
 
         "assert.strictEqual(true, a === b);",
         "assert.strictEqual(false, a === b);",


### PR DESCRIPTION
Before this fix, this lint rule would not report any violations when a message was passed to the assertion function.