### PR TITLE
Add tests to ensure rules have tests and basic rule doc

### DIFF
--- a/docs/rules/no-async-in-loops.md
+++ b/docs/rules/no-async-in-loops.md
@@ -1,4 +1,4 @@
-# Forbid async calls in loops
+# Forbid async calls in loops (no-async-in-loops)
 
 Asynchronous operations are much harder to reason about in loops. To increase
 maintainability, asynchronous operations should not be placed within loops.

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -1,4 +1,4 @@
-# Forbid equality comparisons in assert.ok/assert.notOk
+# Forbid equality comparisons in assert.ok/assert.notOk (no-ok-equality)
 
 Equality comparisons in `assert.ok` or `assert.notOk` calls are not valuable
 because if the assertion fails, QUnit cannot reveal any comparison information.

--- a/docs/rules/resolve-async.md
+++ b/docs/rules/resolve-async.md
@@ -1,4 +1,4 @@
-# Require that all async calls should be resolved in tests
+# Require that all async calls should be resolved in tests (resolve-async)
 
 Asynchronous operations on QUnit tests should be resolved within the scope of
 the test to maximize readability and maintainability. Also, if there are more

--- a/tests/index.js
+++ b/tests/index.js
@@ -37,6 +37,15 @@ describe("index.js", function () {
                     assert.property(index.rules, fileName, `Rule export for ${fileName} not present`);
                 });
 
+                it("should appear in tests", function (done) {
+                    const path = `./tests/lib/rules/${fileName}.js`;
+
+                    fs.access(path, function (err) {
+                        assert.notOk(err, `tests/lib/rules/${fileName}.js should exist`);
+                        done();
+                    });
+                });
+
                 it("should appear in docs", function (done) {
                     const path = `./docs/rules/${fileName}.md`;
 
@@ -44,6 +53,14 @@ describe("index.js", function () {
                         assert.notOk(err, `docs/rules/${fileName}.md should exist`);
                         done();
                     });
+                });
+
+                it("should have the right doc contents", function () {
+                    const path = `./docs/rules/${fileName}.md`;
+                    const fileContents = fs.readFileSync(path, "utf8");
+
+                    const titleRegexp = new RegExp(`# .+ \\(${fileName}\\)`);
+                    assert.ok(fileContents.match(titleRegexp), "includes rule name in title header");
                 });
             });
         });

--- a/tests/index.js
+++ b/tests/index.js
@@ -59,7 +59,7 @@ describe("index.js", function () {
                     const path = `./docs/rules/${fileName}.md`;
                     const fileContents = fs.readFileSync(path, "utf8");
 
-                    const titleRegexp = new RegExp(`# .+ \\(${fileName}\\)`);
+                    const titleRegexp = new RegExp(`^# .+ \\(${fileName}\\)$`, "m");
                     assert.ok(fileContents.match(titleRegexp), "includes rule name in title header");
                 });
             });


### PR DESCRIPTION
This adds two initial tests for ensuring rule consistency. I plan to follow-up with additional tests soon.

Inspired by a similar suite of rule tests in [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember/blob/master/tests/rule-setup.js) and [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint/blob/master/test/unit/rule-setup-test.js).