### PR TITLE
Add fixable notice to rule doc of autofixable rules

### DIFF
--- a/docs/rules/literal-compare-order.md
+++ b/docs/rules/literal-compare-order.md
@@ -1,5 +1,7 @@
 # Ensure comparison assertions have arguments in the right order (literal-compare-order)
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 QUnit's many comparison assertions (`equal`, `strictEqual`, etc.) distinguish
 between an expected value and an actual value, and report incorrect assertions
 accordingly. The QUnit reporters will show how the actual value is different

--- a/docs/rules/no-arrow-tests.md
+++ b/docs/rules/no-arrow-tests.md
@@ -1,5 +1,7 @@
 # Forbid arrow functions as QUnit test/module callbacks (no-arrow-tests)
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 QUnit test and module callbacks can share state by modifying properties of
 `this` within those callbacks.
 

--- a/docs/rules/no-compare-relation-boolean.md
+++ b/docs/rules/no-compare-relation-boolean.md
@@ -1,5 +1,7 @@
 # forbid comparing relational expression to boolean in assertions (no-compare-relation-boolean)
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Sometimes, QUnit assertions contain relations (such as `expected === actual`). Many of these relations can be expressed better using different assertion methods (such as `assert.strictEqual`). However, even for those comparisons which cannot easily be expressed (such as `actual > expected`), comparing those results explicitly to `true` or `false` provides no added value, because the assertion will show that true equals or does not equal true.
 
 In any comparison between a relational expression (`actual > expected`) and a boolean, it is at least possible to convert the assertion to use `assert.ok` or `assert.notOk`. In addition, custom assertions could be used or created to provide better output.

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -1,5 +1,7 @@
 # Forbid equality comparisons in assert.ok/assert.notOk (no-ok-equality)
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Equality comparisons in `assert.ok` or `assert.notOk` calls are not valuable
 because if the assertion fails, QUnit cannot reveal any comparison information.
 Instead, developers should use `assert.equal`, `assert.strictEqual`,

--- a/docs/rules/no-setup-teardown.md
+++ b/docs/rules/no-setup-teardown.md
@@ -1,5 +1,7 @@
 # Forbid setup/teardown module hooks (no-setup-teardown)
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 QUnit supports two hooks at the module level: `beforeEach` and `afterEach`.
 These hooks are run before and after each test, respectively. Before QUnit
 1.16.0, these hooks were known as `setup` and `teardown`, which sometimes

--- a/tests/index.js
+++ b/tests/index.js
@@ -17,6 +17,9 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
+const FIXABLE_MSG =
+    ":wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.";
+
 describe("index.js", function () {
     let ruleFileNames;
 
@@ -58,9 +61,23 @@ describe("index.js", function () {
                 it("should have the right doc contents", function () {
                     const path = `./docs/rules/${fileName}.md`;
                     const fileContents = fs.readFileSync(path, "utf8");
+                    const lines = fileContents.split("\n");
 
-                    const titleRegexp = new RegExp(`^# .+ \\(${fileName}\\)$`, "m");
-                    assert.ok(fileContents.match(titleRegexp), "includes rule name in title header");
+                    // First content should be title.
+                    const titleRegexp = new RegExp(`^# .+ \\(${fileName}\\)$`);
+                    assert.ok(titleRegexp.test(lines[0]), "includes rule name in title header");
+
+                    // Second content should be fixable notice if applicable.
+                    if (index.rules[fileName].meta.fixable) {
+                        assert.equal(lines[1], "", "has blank line between title and fixable notice");
+                        assert.equal(lines[2], FIXABLE_MSG, "includes fixable notice");
+                        assert.equal(lines[3], "", "has blank line after fixable notice");
+                    } else {
+                        assert.ok(
+                            !fileContents.includes(FIXABLE_MSG),
+                            "does not include fixable notice"
+                        );
+                    }
                 });
             });
         });


### PR DESCRIPTION
ESLint rule docs provide this same exact notice. Example: https://eslint.org/docs/rules/no-extra-semi

Also adds a test to ensure rule docs correctly include the fixable notice.

A subsequent follow-up will be to indicate which rules are fixable in the README.md with the :wrench: icon.