### PR TITLE
Add notices to each rule doc indicating which configuration enables the rule

### DIFF
--- a/docs/rules/assert-args.md
+++ b/docs/rules/assert-args.md
@@ -1,5 +1,7 @@
 # Ensure the correct number of assert arguments is used (assert-args)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 QUnit's assertions expect a certain number of arguments based on what sort of
 condition is being evaluated.
 

--- a/docs/rules/literal-compare-order.md
+++ b/docs/rules/literal-compare-order.md
@@ -1,5 +1,7 @@
 # Ensure comparison assertions have arguments in the right order (literal-compare-order)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 QUnit's many comparison assertions (`equal`, `strictEqual`, etc.) distinguish

--- a/docs/rules/no-async-in-loops.md
+++ b/docs/rules/no-async-in-loops.md
@@ -1,5 +1,7 @@
 # Forbid async calls in loops (no-async-in-loops)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 Asynchronous operations are much harder to reason about in loops. To increase
 maintainability, asynchronous operations should not be placed within loops.
 

--- a/docs/rules/no-async-test.md
+++ b/docs/rules/no-async-test.md
@@ -1,5 +1,7 @@
 # Forbid the use of asyncTest or QUnit.asyncTest (no-async-test)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 is deprecating `QUnit.asyncTest()` in favor of `assert.async()` within tests. This rule will flag `asyncTest` and `QUnit.asyncTest` calls and recommend that you use `assert.async()` instead.
 
 ## Rule Details

--- a/docs/rules/no-commented-tests.md
+++ b/docs/rules/no-commented-tests.md
@@ -1,5 +1,7 @@
 # Forbid commented tests (no-commented-tests)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 When developing non-trivial projects, it is unfortunately realistic that unit
 tests may need to be temporarily prevented from running until an upstream
 problem is fixed. However, in that case, the test should be disabled in a way

--- a/docs/rules/no-global-assertions.md
+++ b/docs/rules/no-global-assertions.md
@@ -1,5 +1,7 @@
 # Forbid the use of global QUnit assertions (no-global-assertions)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 is deprecating and removing global QUnit assertions such as `ok()`, requiring consumers to instead use scoped assertions provided on the test callback argument.
 
 ## Rule Details

--- a/docs/rules/no-global-expect.md
+++ b/docs/rules/no-global-expect.md
@@ -1,5 +1,7 @@
 # Forbid the use of global expect (no-global-expect)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 is deprecating and removing the global `expect` function. This rule will warn when the global `expect` function is used.
 
 ## Rule Details

--- a/docs/rules/no-global-module-test.md
+++ b/docs/rules/no-global-module-test.md
@@ -1,5 +1,7 @@
 # Forbid the use of global module/test/asyncTest (no-global-module-test)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 is deprecating and removing global functions related to declaring tests and modules. This rule will warn when the global functions are used.
 
 ## Rule Details

--- a/docs/rules/no-global-stop-start.md
+++ b/docs/rules/no-global-stop-start.md
@@ -1,5 +1,7 @@
 # Forbid use of global stop()/start() (no-global-stop-start)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 is deprecating and removing all of its global exports, including
 `stop()` and `start()`.
 

--- a/docs/rules/no-identical-names.md
+++ b/docs/rules/no-identical-names.md
@@ -1,5 +1,7 @@
 # Forbid identical test and module names (no-identical-names)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 Having identical names for two different tests or modules may create
 confusion. For example, when a test with the same name as another test
 in the same module fails, it is harder to know which one failed and

--- a/docs/rules/no-init.md
+++ b/docs/rules/no-init.md
@@ -1,5 +1,7 @@
 # Forbids use of QUnit.init (no-init)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 Early versions of QUnit exposed the `QUnit.init()` function, which allowed
 consumers to reinitialize the QUnit test runner. This has been discouraged for
 a long time since QUnit now automatically invokes this method as needed. In

--- a/docs/rules/no-jsdump.md
+++ b/docs/rules/no-jsdump.md
@@ -1,5 +1,7 @@
 # Forbid use of QUnit.jsDump() (no-jsdump)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 When QUnit was first developed, it used the `jsDump` library for serializing
 objects as strings. Since then, QUnit has forked and evolved the library. To
 reflect that this new serialization code no longer uses jsDump, `QUnit.dump()`

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -1,5 +1,7 @@
 # Forbid equality comparisons in assert.ok/assert.notOk (no-ok-equality)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Equality comparisons in `assert.ok` or `assert.notOk` calls are not valuable

--- a/docs/rules/no-only.md
+++ b/docs/rules/no-only.md
@@ -1,5 +1,7 @@
 # Forbid the use of QUnit.only (no-only)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 `QUnit.only` is useful for restricting a test run to just one test while developing, but committing a test file using this function to a repository is dangerous because it will ensure that the rest of the test suite is not run.
 
 ## Rule Details

--- a/docs/rules/no-qunit-push.md
+++ b/docs/rules/no-qunit-push.md
@@ -1,5 +1,7 @@
 # Forbid the use of QUnit.push (no-qunit-push)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 When writing custom assertions, the proper way to log an assertion result
 used to be calling `QUnit.push()` with the assertion result data. However, in
 order to allow for better control of test context, `QUnit.push` has been

--- a/docs/rules/no-qunit-start-in-tests.md
+++ b/docs/rules/no-qunit-start-in-tests.md
@@ -1,5 +1,7 @@
 # Forbid QUnit.start() within tests or test hooks (no-qunit-start-in-tests)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 The purpose of this rule is to ensure that `QUnit.start()` is not used within tests or test hooks.
 
 Prior to QUnit 2.0, `QUnit.start()` was the way to resume an asynchronous test. However, with QUnit 2.0, that usage has been disallowed, and now `QUnit.start()` should only be used to start the test runner for the first time (if `QUnit.config.autostart` is set to `false`.

--- a/docs/rules/no-qunit-stop.md
+++ b/docs/rules/no-qunit-stop.md
@@ -1,5 +1,7 @@
 # Forbid the use of QUnit.stop (no-qunit-stop)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit's handling of asynchronous tests used to be via tracking a global
 semaphore and not starting a test until the previous test had decremented the
 semaphore. However, in order to avoid tests interfering with each other,

--- a/docs/rules/no-reassign-log-callbacks.md
+++ b/docs/rules/no-reassign-log-callbacks.md
@@ -1,5 +1,9 @@
 # Forbid overwriting of QUnit logging callbacks (no-reassign-log-callbacks)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 In early versions of QUnit, it was possible to create logging functions that
 would be invoked as QUnit processed tests and modules by assigning to specific
 properties of the QUnit object. This became problematic when multiple logging
@@ -12,6 +16,7 @@ and recommend that the corresponding functions be invoked instead.
 ## Rule Details
 
 The full list of QUnit logging callbacks are as follows:
+
 * `QUnit.begin()`
 * `Qunit.done()`
 * `QUnit.log()`

--- a/docs/rules/no-reset.md
+++ b/docs/rules/no-reset.md
@@ -1,5 +1,9 @@
 # Forbids use of QUnit.reset (no-reset)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 Early versions of QUnit exposed the `QUnit.reset()` function, which allowed
 consumers to invoke the internal QUnit fixture reset logic. This has been
 discouraged for a long time since QUnit now automatically invokes this method

--- a/docs/rules/no-setup-teardown.md
+++ b/docs/rules/no-setup-teardown.md
@@ -1,5 +1,7 @@
 # Forbid setup/teardown module hooks (no-setup-teardown)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 QUnit supports two hooks at the module level: `beforeEach` and `afterEach`.

--- a/docs/rules/no-test-expect-argument.md
+++ b/docs/rules/no-test-expect-argument.md
@@ -1,5 +1,7 @@
 # forbid expect argument in QUnit.test (no-test-expect-argument)
 
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 is deprecating expect counts as the second argument of `QUnit.test`. Users are expected to use `assert.expect()` instead.
 
 ## Rule Details

--- a/docs/rules/no-throws-string.md
+++ b/docs/rules/no-throws-string.md
@@ -1,5 +1,9 @@
 # forbid assert.throws() with block, string, and message (no-throws-string)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
+:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+
 QUnit 2.0 has deprecated the `assert.throws(block, string, message)` form of
 `assert.throws()`. This rule can be used to flag uses of the deprecated form
 and convert them to use a regular expression or some other predicate.

--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -1,5 +1,7 @@
 # Ensure that `expect` is called (require-expect)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 QUnit's `assert.expect(...)` helps developers create tests that correctly fail
 when their expected number of assertions are not called. QUnit will throw an
 error if no assertions are called by the time the test ends unless a developer

--- a/docs/rules/resolve-async.md
+++ b/docs/rules/resolve-async.md
@@ -1,5 +1,7 @@
 # Require that all async calls should be resolved in tests (resolve-async)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 Asynchronous operations on QUnit tests should be resolved within the scope of
 the test to maximize readability and maintainability. Also, if there are more
 async setup calls than async resolution calls, the test runner will hang, so


### PR DESCRIPTION
ESLint rule docs provide this same exact notice. Example: https://eslint.org/docs/rules/no-extra-semi

Also adds a test to ensure rule docs correctly include the notice.

This is a follow-up to https://github.com/platinumazure/eslint-plugin-qunit/pull/106 where I added a fixable notice to rule docs.