### PR TITLE
Build: Update lcov location in coveralls action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,4 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./build/coverage/lcov.info


### PR DESCRIPTION
Let's see if this fixes the Coveralls issue in the CI action.