### PR TITLE
Add new rule `no-assert-equal-boolean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each rule has emojis denoting:
 | :white_check_mark::wrench: | [literal-compare-order](./docs/rules/literal-compare-order.md) |
 | :wrench: | [no-arrow-tests](./docs/rules/no-arrow-tests.md) |
 |  | [no-assert-equal](./docs/rules/no-assert-equal.md) |
+| :wrench: | [no-assert-equal-boolean](./docs/rules/no-assert-equal-boolean.md) |
 | :white_check_mark: | [no-assert-logical-expression](./docs/rules/no-assert-logical-expression.md) |
 |  | [no-assert-ok](./docs/rules/no-assert-ok.md) |
 | :white_check_mark: | [no-async-in-loops](./docs/rules/no-async-in-loops.md) |

--- a/docs/rules/no-assert-equal-boolean.md
+++ b/docs/rules/no-assert-equal-boolean.md
@@ -1,0 +1,36 @@
+# Require use of boolean assertions (no-assert-equal-boolean)
+
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+The boolean assertion functions `assert.true()` and `assert.false()` are available as of QUnit 2.11. These assertions can be stricter and clearer about intent when compared to using other assertion functions for boolean comparisons.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+QUnit.test('Name', function (assert) { assert.equal(a, true); });
+```
+
+```js
+QUnit.test('Name', function (assert) { assert.strictEqual(a, true); });
+```
+
+```js
+QUnit.test('Name', function (assert) { assert.deepEqual(false, a); });
+```
+
+The following patterns are not considered warnings:
+
+```js
+QUnit.test('Name', function (assert) { assert.true(a); });
+```
+
+```js
+QUnit.test('Name', function (assert) { assert.false(a); });
+```
+
+## Further Reading
+
+* [assert.true()](https://api.qunitjs.com/assert/true/)
+* [assert.false()](https://api.qunitjs.com/assert/false/)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
         "literal-compare-order": require("./lib/rules/literal-compare-order"),
         "no-arrow-tests": require("./lib/rules/no-arrow-tests"),
         "no-assert-equal": require("./lib/rules/no-assert-equal"),
+        "no-assert-equal-boolean": require("./lib/rules/no-assert-equal-boolean"),
         "no-assert-logical-expression": require("./lib/rules/no-assert-logical-expression"),
         "no-assert-ok": require("./lib/rules/no-assert-ok"),
         "no-async-in-loops": require("./lib/rules/no-async-in-loops"),

--- a/lib/rules/no-assert-equal-boolean.js
+++ b/lib/rules/no-assert-equal-boolean.js
@@ -1,0 +1,108 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("assert"),
+    utils = require("../utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const EQUALITY_ASSERTIONS = ["equal", "deepEqual", "strictEqual"];
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require use of boolean assertions",
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal-boolean.md"
+        },
+        fixable: "code",
+        messages: {
+            useAssertTrueOrFalse: "Use `assert.true or `assert.false` for boolean assertions."
+        },
+        schema: []
+    },
+
+    create: function (context) {
+        // Declare a test stack in case of nested test cases (not currently supported by QUnit).
+        const testStack = [];
+
+        function getCurrentAssertContextVariable() {
+            assert(testStack.length, "Test stack should not be empty");
+
+            return testStack[testStack.length - 1].assertVar;
+        }
+
+        // Check for something like `equal(...)` without assert parameter.
+        function isGlobalEqualityAssertion(calleeNode) {
+            return calleeNode &&
+                calleeNode.type === "Identifier" &&
+                EQUALITY_ASSERTIONS.includes(calleeNode.name);
+        }
+
+        // Check for something like `assert.equal(...)`.
+        function isAssertEquality(calleeNode) {
+            return calleeNode &&
+                calleeNode.type === "MemberExpression" &&
+                calleeNode.property.type === "Identifier" &&
+                EQUALITY_ASSERTIONS.includes(calleeNode.property.name) &&
+                calleeNode.object.type === "Identifier" &&
+                calleeNode.object.name === getCurrentAssertContextVariable();
+        }
+
+        // Check for something like `equal(...)` or `assert.equal(...)`.
+        function isEqualityAssertion(calleeNode) {
+            return isGlobalEqualityAssertion(calleeNode) ||
+                isAssertEquality(calleeNode);
+        }
+
+        // Finds the first boolean argument of a CallExpression if one exists.
+        function getBooleanArgument(node) {
+            return node.arguments.length >= 2 &&
+                [node.arguments[0], node.arguments[1]]
+                    .find(arg => arg.type === "Literal" && (arg.value === true || arg.value === false));
+        }
+
+        function reportError(node) {
+            context.report({
+                node: node,
+                messageId: "useAssertTrueOrFalse",
+                fix(fixer) {
+                    const booleanArgument = getBooleanArgument(node);
+                    const newAssertionFunctionName = booleanArgument.value ? "true" : "false";
+
+                    const sourceCode = context.getSourceCode();
+                    const newArgsTextArray = node.arguments.filter(arg => arg !== booleanArgument).map(arg => sourceCode.getText(arg));
+                    const newArgsTextJoined = newArgsTextArray.join(", ");
+
+                    const assertVariablePrefix = node.callee.type === "Identifier" ? "" : `${getCurrentAssertContextVariable()}.`;
+
+                    return fixer.replaceText(node, `${assertVariablePrefix}${newAssertionFunctionName}(${newArgsTextJoined})`);
+                }
+            });
+        }
+
+        return {
+            "CallExpression": function (node) {
+                /* istanbul ignore else: correctly does nothing */
+                if (utils.isTest(node.callee) || utils.isAsyncTest(node.callee)) {
+                    testStack.push({
+                        assertVar: utils.getAssertContextNameForTest(node.arguments)
+                    });
+                } else if (testStack.length && isEqualityAssertion(node.callee) && getBooleanArgument(node)) {
+                    reportError(node);
+                }
+            },
+            "CallExpression:exit": function (node) {
+                /* istanbul ignore else: correctly does nothing */
+                if (utils.isTest(node.callee) || utils.isAsyncTest(node.callee)) {
+                    testStack.pop();
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-assert-equal-boolean.js
+++ b/tests/lib/rules/no-assert-equal-boolean.js
@@ -1,0 +1,147 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-assert-equal-boolean"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-assert-equal-boolean", rule, {
+    valid: [
+        // assert param
+        "QUnit.test('Name', function (assert) { assert.equal(a, b); });",
+        "QUnit.test('Name', function (assert) { assert.strictEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });",
+
+        // non-standard assert param
+        "QUnit.test('Name', function (foo) { foo.equal(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.strictEqual(a, b); });",
+        "QUnit.test('Name', function (foo) { foo.deepEqual(a, b); });",
+
+        // assert param but using global assert
+        "QUnit.test('Name', function (assert) { equal(a, b); });",
+        "QUnit.test('Name', function (assert) { strictEqual(a, b); });",
+        "QUnit.test('Name', function (assert) { deepEqual(a, b); });",
+
+        // Using global assert
+        "QUnit.test('Name', function () { equal(a, b); });",
+        "QUnit.test('Name', function () { strictEqual(a, b); });",
+        "QUnit.test('Name', function () { deepEqual(a, b); });",
+
+        // boolean as message parameter should be ignored
+        "QUnit.test('Name', function (assert) { assert.equal(a, b, true); });",
+        "QUnit.test('Name', function (assert) { assert.equal(a, b, false); });",
+
+        // non-boolean literals allowed
+        "QUnit.test('Name', function (assert) { assert.equal(a, 123); });",
+
+        // booleans allowed with other assertion functions
+        "QUnit.test('Name', function (assert) { assert.true(true); });",
+        "QUnit.test('Name', function (assert) { assert.false(false); });",
+        "QUnit.test('Name', function (assert) { assert.notEqual(a, true); });",
+        "QUnit.test('Name', function (assert) { assert.notStrictEqual(a, true); });",
+        "QUnit.test('Name', function (assert) { assert.notDeepEqual(a, true); });",
+        "QUnit.test('Name', function (assert) { assert.notPropEqual(a, false); });",
+        "QUnit.test('Name', function (assert) { assert.propEqual(a, true); });",
+
+        // not within test context
+        "equal(a, true);"
+    ],
+
+    invalid: [
+        // assert param
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(a, true); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(a); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(a, false); });",
+            output: "QUnit.test('Name', function (assert) { assert.false(a); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // deepEqual
+        {
+            code: "QUnit.test('Name', function (assert) { assert.deepEqual(a, true); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(a); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // strictEqual
+        {
+            code: "QUnit.test('Name', function (assert) { assert.strictEqual(a, true); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(a); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // with message param
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(a, true, 'msg'); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(a, 'msg'); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // Boolean as first parameter
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(true, b); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(b); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(false, b); });",
+            output: "QUnit.test('Name', function (assert) { assert.false(b); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // multiple booleans
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(true, true); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(true); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(false, true); });",
+            output: "QUnit.test('Name', function (assert) { assert.false(true); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(true, false); });",
+            output: "QUnit.test('Name', function (assert) { assert.true(false); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+        {
+            code: "QUnit.test('Name', function (assert) { assert.equal(false, false); });",
+            output: "QUnit.test('Name', function (assert) { assert.false(false); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // non-standard assert param
+        {
+            code: "QUnit.test('Name', function (foo) { foo.equal(true, b); });",
+            output: "QUnit.test('Name', function (foo) { foo.true(b); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // assert param but using global assert
+        {
+            code: "QUnit.test('Name', function (assert) { equal(a, true); });",
+            output: "QUnit.test('Name', function (assert) { true(a); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // using global assert
+        {
+            code: "QUnit.test('Name', function () { equal(a, true); });",
+            output: "QUnit.test('Name', function () { true(a); });",
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        }
+    ]
+});


### PR DESCRIPTION
For enforcing usage of new `assert.true(...)` or `assert.false(...)` assertions.