### PR TITLE
Add `qunit` plugin to configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ module.exports = {
     // eslint-disable-next-line sort-keys
     configs: {
         recommended: {
+            plugins: ["qunit"],
             rules: {
                 "qunit/assert-args": "error",
                 "qunit/literal-compare-order": "error",
@@ -69,6 +70,7 @@ module.exports = {
             }
         },
         two: {
+            plugins: ["qunit"],
             rules: {
                 "qunit/no-async-test": "error",
                 "qunit/no-global-assertions": "error",

--- a/tests/index.js
+++ b/tests/index.js
@@ -108,4 +108,15 @@ describe("index.js", function () {
             });
         });
     });
+
+    describe("configs", function () {
+        for (const configName of Object.keys(index.configs)) {
+            const config = index.configs[configName];
+            describe(configName, function () {
+                it("has the right plugins", function () {
+                    assert.deepStrictEqual(config.plugins, ["qunit"]);
+                });
+            });
+        }
+    });
 });


### PR DESCRIPTION
Fixes #122.

This makes it easier for consumers to use these configs without having to specify the plugin themselves. 