### PR TITLE
Add rule documentation page URLs to rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -165,6 +165,9 @@
         "eslint-plugin/prefer-output-null": "error",
         "eslint-plugin/prefer-placeholders": "error",
         "eslint-plugin/report-message-format": ["error", "^[A-Z].*\\.$"],
+        "eslint-plugin/require-meta-docs-url": ["error", {
+            "pattern": "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/{{name}}.md"
+        }],
         "eslint-plugin/require-meta-schema": "error",
         "eslint-plugin/test-case-property-ordering": "error",
         "eslint-plugin/test-case-shorthand-strings": "error"

--- a/lib/rules/assert-args.js
+++ b/lib/rules/assert-args.js
@@ -19,7 +19,8 @@ module.exports = {
     meta: {
         docs: {
             description: "ensure correct number of assert arguments is used",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md"
         },
         messages: {
             unexpectedArgCount: "Unexpected call to {{callee}} with {{argCount}} arguments.",

--- a/lib/rules/literal-compare-order.js
+++ b/lib/rules/literal-compare-order.js
@@ -28,7 +28,8 @@ module.exports = {
     meta: {
         docs: {
             description: "ensure comparison assertions have arguments in the right order",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/literal-compare-order.md"
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -20,7 +20,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid arrow functions as QUnit test/module callbacks",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md"
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -19,7 +19,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid the use of assert.equal",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md"
         },
         messages: {
             unexpectedGlobalEqual: "Unexpected equal. Use strictEqual, deepEqual, or propEqual.",

--- a/lib/rules/no-assert-logical-expression.js
+++ b/lib/rules/no-assert-logical-expression.js
@@ -19,7 +19,8 @@ module.exports = {
         docs: {
             description: "forbid binary logical expressions in assert arguments",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-logical-expression.md"
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-async-in-loops.js
+++ b/lib/rules/no-async-in-loops.js
@@ -15,7 +15,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid async calls in loops",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-in-loops.md"
         },
         messages: {
             unexpectedAsyncInLoop: "Unexpected {{call}} in {{loopTypeText}}."

--- a/lib/rules/no-async-test.js
+++ b/lib/rules/no-async-test.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid the use of asyncTest or QUnit.asyncTest",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-test.md"
         },
         messages: {
             unexpectedAsyncTest: "Unexpected asynchronous test. Use assert.async() instead."

--- a/lib/rules/no-commented-tests.js
+++ b/lib/rules/no-commented-tests.js
@@ -12,7 +12,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid commented tests",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-commented-tests.md"
         },
         messages: {
             unexpectedTestInComment: "Unexpected \"{{callee}}\" in comment. Use QUnit.skip outside of a comment."

--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -19,7 +19,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid comparing relational expression to boolean in assertions",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-compare-relation-boolean.md"
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-conditional-assertions.js
+++ b/lib/rules/no-conditional-assertions.js
@@ -31,7 +31,8 @@ module.exports = {
         docs: {
             description: "forbid assertions within if statements or conditional expressions",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-conditional-assertions.md"
         },
         fixable: null,  // or "code" or "whitespace"
         messages: {

--- a/lib/rules/no-early-return.js
+++ b/lib/rules/no-early-return.js
@@ -19,7 +19,8 @@ module.exports = {
     meta: {
         docs: {
             description: "prevent early return in a QUnit test",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-early-return.md"
         },
         messages: {
             noEarlyReturn: "Do not return early from a QUnit test."

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid global QUnit assertions",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-assertions.md"
         },
         messages: {
             unexpectedGlobalAssertion: "Unexpected global `{{ assertion }}` assertion."

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -12,7 +12,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid global expect",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-expect.md"
         },
         messages: {
             unexpectedGlobalExpect: "Unexpected global expect."

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid global module/test/asyncTest",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-module-test.md"
         },
         messages: {
             unexpectedGlobalModuleTest: "Unexpected global `{{ callee }}`."

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -14,7 +14,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid global stop/start",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-stop-start.md"
         },
         messages: {
             unexpectedGlobalStopStart: "Unexpected global {{callee}}() call."

--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "Forbid identical test and module names",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-identical-names.md"
         },
         messages: {
             duplicateTest: "Test name is used on line {{ line }} in the same module.",

--- a/lib/rules/no-init.js
+++ b/lib/rules/no-init.js
@@ -14,7 +14,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid use of QUnit.init",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-init.md"
         },
         messages: {
             noInit: "Do not use QUnit.init()."

--- a/lib/rules/no-jsdump.js
+++ b/lib/rules/no-jsdump.js
@@ -12,7 +12,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid use of QUnit.jsDump",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-jsdump.md"
         },
         messages: {
             noJsDump: "Use QUnit.dump() instead of QUnit.jsDump()."

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -68,7 +68,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid the use of assert.equal/assert.ok/assert.notEqual/assert.notOk (can be configured)",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-loose-assertions.md"
         },
         messages: {
             [GLOBAL_ERROR_MESSAGE_ID]: "Unexpected {{assertion}}. Use strictEqual, notStrictEqual, deepEqual, or propEqual.",

--- a/lib/rules/no-negated-ok.js
+++ b/lib/rules/no-negated-ok.js
@@ -15,7 +15,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid negation in assert.ok/assert.notOk",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-negated-ok.md"
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "Forbid nested QUnit.test() calls",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-nested-tests.md"
         },
         messages: {
             noNestedTests: "Using QUnit.test inside of another QUnit.test is not allowed."

--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -14,7 +14,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid equality comparisons in assert.ok/assert.notOk",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-ok-equality.md"
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid QUnit.only",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-only.md"
         },
         messages: {
             noQUnitOnly: "Unexpected only() call."

--- a/lib/rules/no-qunit-push.js
+++ b/lib/rules/no-qunit-push.js
@@ -12,7 +12,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid QUnit.push",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-push.md"
         },
         messages: {
             noQUnitPush: "Do not use QUnit.push()."

--- a/lib/rules/no-qunit-start-in-tests.js
+++ b/lib/rules/no-qunit-start-in-tests.js
@@ -19,7 +19,8 @@ module.exports = {
         docs: {
             description: "forbid QUnit.start() within tests or test hooks",
             category: "Possible Errors",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-start-in-tests.md"
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-qunit-stop.js
+++ b/lib/rules/no-qunit-stop.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "Forbid QUnit.stop",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-stop.md"
         },
         messages: {
             noQUnitStop: "Use assert.async() instead of QUnit.stop()."

--- a/lib/rules/no-reassign-log-callbacks.js
+++ b/lib/rules/no-reassign-log-callbacks.js
@@ -14,7 +14,8 @@ module.exports = {
     meta: {
         docs: {
             description: "Forbid overwriting of QUnit logging callbacks",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-reassign-log-callbacks.md"
         },
         messages: {
             noReassignLogCallbacks: "Do not reassign QUnit log callbacks."

--- a/lib/rules/no-reset.js
+++ b/lib/rules/no-reset.js
@@ -14,7 +14,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid QUnit.reset",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-reset.md"
         },
         messages: {
             noReset: "Do not use QUnit.reset()."

--- a/lib/rules/no-setup-teardown.js
+++ b/lib/rules/no-setup-teardown.js
@@ -16,7 +16,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid setup/teardown module hooks",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-setup-teardown.md"
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-skip.js
+++ b/lib/rules/no-skip.js
@@ -19,7 +19,8 @@ module.exports = {
         docs: {
             description: "forbid QUnit.skip",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-skip.md"
         },
         messages: {
             noQUnitSkip: "Unexpected skip() call."

--- a/lib/rules/no-test-expect-argument.js
+++ b/lib/rules/no-test-expect-argument.js
@@ -18,7 +18,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid expect argument in QUnit.test",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-test-expect-argument.md"
         },
         messages: {
             noExpectArgument: "Do not use expect argument in {{callee}}()."

--- a/lib/rules/no-throws-string.js
+++ b/lib/rules/no-throws-string.js
@@ -45,7 +45,8 @@ module.exports = {
     meta: {
         docs: {
             description: "forbid assert.throws() with block, string, and message args",
-            category: "Possible errors"
+            category: "Possible errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-throws-string.md"
         },
         messages: {
             noThrowsWithString: "Do not use {{callee}}(block, string, string)."

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -15,7 +15,8 @@ module.exports = {
     meta: {
         docs: {
             description: "ensure that expect is called",
-            category: "Best Practices"
+            category: "Best Practices",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/require-expect.md"
         },
         messages: {
             expectRequired: "Test is missing `{{expect}}()` call.",

--- a/lib/rules/resolve-async.js
+++ b/lib/rules/resolve-async.js
@@ -14,7 +14,8 @@ module.exports = {
     meta: {
         docs: {
             description: "require that async calls are resolved",
-            category: "Possible Errors"
+            category: "Possible Errors",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/resolve-async.md"
         },
         messages: {
             needMoreStartCalls: "Need {{semaphore}} more start() {{callOrCalls}}.",


### PR DESCRIPTION
This allows IDEs to link directly to the rule documentation when hovering over rule violations.

Autofixed and enforces this using this rule: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-docs-url.md