### PR TITLE
Catch duplicate titles in ancestor modules in `no-identical-names` rule

### DIFF
--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -28,7 +28,8 @@ module.exports = {
         },
         messages: {
             duplicateTest: "Test name is used on line {{ line }} in the same module.",
-            duplicateModule: "Module name is used on line {{ line }}."
+            duplicateModule: "Module name is used by sibling on line {{ line }}.",
+            duplicateModuleAncestor: "Module name is used by ancestor on line {{ line }}."
         },
         schema: []
     },
@@ -73,12 +74,23 @@ module.exports = {
 
                 // Check if we have seen the same nested module title parts before.
                 const duplicateModuleTitle = moduleNames.find(obj => areArraysEqual(obj.titleParts, titleParts));
-
                 if (duplicateModuleTitle) {
                     context.report({
                         node: node.arguments[0],
                         messageId: "duplicateModule",
                         data: duplicateModuleTitle
+                    });
+                }
+
+                // Check if we have seen the same title in any ancestor modules.
+                const duplicateAncestorModuleTitle = modulesStack.find(moduleNode => moduleNode.arguments[0].value === title);
+                if (duplicateAncestorModuleTitle) {
+                    context.report({
+                        node: node.arguments[0],
+                        messageId: "duplicateModuleAncestor",
+                        data: {
+                            line: duplicateAncestorModuleTitle.arguments[0].loc.start.line
+                        }
                     });
                 }
 

--- a/tests/lib/rules/no-identical-names.js
+++ b/tests/lib/rules/no-identical-names.js
@@ -199,6 +199,20 @@ ruleTester.run("no-identical-title", rule, {
                 column: 12,
                 line: 3
             }]
+        },
+        {
+            code: outdent`
+                module("name1", function() {
+                    module("name1", function() {});
+                });
+            `,
+            errors: [{
+                messageId: "duplicateModuleAncestor",
+                data: { line: 1 },
+                column: 12,
+                line: 2
+            }]
         }
+
     ]
 });


### PR DESCRIPTION
Fixes #126.