### PR TITLE
Allow tests with identical names in different modules in `no-identical-names` rule

### DIFF
--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -14,11 +14,6 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
-
-function areArraysEqual(arr1, arr2) {
-    return arr1.length === arr2.length && arr1.every((item, index) => item === arr2[index]);
-}
-
 module.exports = {
     meta: {
         docs: {
@@ -35,9 +30,13 @@ module.exports = {
     },
 
     create: function (context) {
-        const modulesStack = [];
-        const moduleNames = [];
-        const testNames = [];
+        const TOP_LEVEL_MODULE_NODE = "top-level-module"; //  Constant representing the implicit top-level module.
+        const modulesStack = [TOP_LEVEL_MODULE_NODE];
+        const mapModuleNodeToInfo = new Map();
+        mapModuleNodeToInfo.set(TOP_LEVEL_MODULE_NODE, {
+            modules: [], // Children module nodes.
+            tests: [] // Children test nodes.
+        });
 
         //----------------------------------------------------------------------
         // Helper functions
@@ -47,43 +46,61 @@ module.exports = {
             return node.arguments && node.arguments[0] && node.arguments[0].type === "Literal";
         }
 
-        function handleTestNames(node, title) {
-            if (utils.isTest(node.callee)) {
-                const duplicateTestTitle = testNames.find(t => t.title === title);
+        function getCurrentModuleNode() {
+            const parentModule = mapModuleNodeToInfo.get(modulesStack[modulesStack.length - 1]);
+            if (parentModule.modules.length > 0) {
+                // Find the last function-less module at the current level if one exists, i.e: module('foo');
+                const lastFunctionLessModule = parentModule.modules.reverse().find(node => node.arguments.length === 1);
+                if (lastFunctionLessModule) {
+                    return lastFunctionLessModule;
+                }
+            }
+            return modulesStack[modulesStack.length - 1];
+        }
 
+        function handleTestNames(node) {
+            if (utils.isTest(node.callee)) {
+                const title = node.arguments[0].value;
+                const currentModuleNode = getCurrentModuleNode();
+                const currentModuleInfo = mapModuleNodeToInfo.get(currentModuleNode);
+
+                // Check if we have seen this test name in the current module yet.
+                const duplicateTestTitle = currentModuleInfo.tests.find(t => t.arguments[0].value === title);
                 if (duplicateTestTitle) {
                     context.report({
                         node: node.arguments[0],
                         messageId: "duplicateTest",
-                        data: duplicateTestTitle
+                        data: {
+                            line: duplicateTestTitle.arguments[0].loc.start.line
+                        }
                     });
                 }
 
-                testNames.push({
-                    title,
-                    line: node.arguments[0].loc.start.line
-                });
+                // Add this test to the current module's list of tests.
+                currentModuleInfo.tests.push(node);
             }
         }
 
-        function handleModuleNames(node, title) {
+        function handleModuleNames(node) {
             if (utils.isModule(node.callee)) {
-                // Get the nested module title parts.
-                const ancestorTitleParts = modulesStack.map(moduleNode => moduleNode.arguments[0].value);
-                const titleParts = [...ancestorTitleParts, title]; // Example: ["Module", "Submodule"]
+                const title = node.arguments[0].value;
+                const currentModuleNode = modulesStack[modulesStack.length - 1];
+                const currentModuleInfo = mapModuleNodeToInfo.get(currentModuleNode);
 
-                // Check if we have seen the same nested module title parts before.
-                const duplicateModuleTitle = moduleNames.find(obj => areArraysEqual(obj.titleParts, titleParts));
+                // Check if we have seen the same title in a sibling module.
+                const duplicateModuleTitle = currentModuleInfo.modules.find(moduleNode => moduleNode.arguments[0].value === title);
                 if (duplicateModuleTitle) {
                     context.report({
                         node: node.arguments[0],
                         messageId: "duplicateModule",
-                        data: duplicateModuleTitle
+                        data: {
+                            line: duplicateModuleTitle.loc.start.line
+                        }
                     });
                 }
 
                 // Check if we have seen the same title in any ancestor modules.
-                const duplicateAncestorModuleTitle = modulesStack.find(moduleNode => moduleNode.arguments[0].value === title);
+                const duplicateAncestorModuleTitle = modulesStack.filter(moduleNode => moduleNode !== TOP_LEVEL_MODULE_NODE).find(moduleNode => moduleNode.arguments[0].value === title);
                 if (duplicateAncestorModuleTitle) {
                     context.report({
                         node: node.arguments[0],
@@ -94,13 +111,13 @@ module.exports = {
                     });
                 }
 
-                moduleNames.push({
-                    titleParts,
-                    line: node.arguments[0].loc.start.line
-                });
-
                 // Entering a module so push it onto the stack.
                 modulesStack.push(node);
+                mapModuleNodeToInfo.set(node, {
+                    modules: [],
+                    tests: []
+                });
+                currentModuleInfo.modules.push(node); // Add to parent module's list of children modules.
             }
         }
 
@@ -110,17 +127,12 @@ module.exports = {
 
         return {
             "CallExpression": function (node) {
-                if (utils.isModule(node.callee)) {
-                    testNames.length = 0;
-                }
-
                 if (!isFirstArgLiteral(node)) {
                     return;
                 }
 
-                const title = node.arguments[0].value;
-                handleTestNames(node, title);
-                handleModuleNames(node, title);
+                handleModuleNames(node);
+                handleTestNames(node);
             },
 
             "CallExpression:exit": function (node) {

--- a/tests/lib/rules/no-identical-names.js
+++ b/tests/lib/rules/no-identical-names.js
@@ -68,6 +68,29 @@ ruleTester.run("no-identical-title", rule, {
             }
         },
 
+        // Tests with identical names are allowed if they are in different modules.
+        outdent`
+            test('it1', function (assert) {});
+            module('module1', function () {
+                module('module2', function () {
+                    test('it1', function (assert) {});
+                });
+                test('it1', function (assert) {});
+            });
+        `,
+        outdent`
+            module('module1', function () {
+                test('it1', function (assert) {});
+                module('module2');
+                test('it1', function (assert) {}); // Part of module2
+            });
+        `,
+        outdent`
+            test("it1", function() {});
+            module("module1");
+            test("it1", function() {}); // Part of module1.
+        `,
+
         // Nested modules
         outdent`
             module("module1", function() {
@@ -172,6 +195,20 @@ ruleTester.run("no-identical-title", rule, {
         },
         {
             code: outdent `
+                module("module1", function() {});
+                test("it1", function() {});
+                module("module2", function() {});
+                test("it1", function() {});
+            `,
+            errors: [{
+                messageId: "duplicateTest",
+                data: { line: 2 },
+                column: 6,
+                line: 4
+            }]
+        },
+        {
+            code: outdent `
                 module("module1", function() {
                     module("module2", function() {
                         test("it", function() {});
@@ -211,6 +248,21 @@ ruleTester.run("no-identical-title", rule, {
                 data: { line: 1 },
                 column: 12,
                 line: 2
+            }]
+        },
+        {
+            code: outdent`
+                module("name1", function() {
+                    test('it1', function() {});
+                    module("name2", function() {});
+                    test('it1', function() {});
+                });
+            `,
+            errors: [{
+                messageId: "duplicateTest",
+                data: { line: 2 },
+                column: 10,
+                line: 4
             }]
         }
 


### PR DESCRIPTION
Significantly refactors/simplifies logic.

Fixes #130.