### PR TITLE
Only detect true globals in `no-global-*` rules

### DIFF
--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -8,7 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const utils = require("../utils");
+const { getAssertionNames } = require("../utils");
+const { ReferenceTracker } = require("eslint-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -29,8 +30,14 @@ module.exports = {
 
     create: function (context) {
         return {
-            "CallExpression": function (node) {
-                if (node.callee.type === "Identifier" && utils.isAssertion(node.callee)) {
+            "Program": function () {
+                const tracker = new ReferenceTracker(context.getScope());
+                const traceMap = {};
+                getAssertionNames().forEach(assertionName => {
+                    traceMap[assertionName] = { [ReferenceTracker.CALL]: true };
+                });
+
+                for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
                     context.report({
                         node: node,
                         messageId: "unexpectedGlobalAssertion",

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { ReferenceTracker } = require("eslint-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -23,11 +29,16 @@ module.exports = {
 
     create: function (context) {
         return {
-            "CallExpression[callee.name='expect']": function (node) {
-                context.report({
-                    node: node,
-                    messageId: "unexpectedGlobalExpect"
-                });
+            "Program": function () {
+                const tracker = new ReferenceTracker(context.getScope());
+                const traceMap = { expect: { [ReferenceTracker.CALL]: true } };
+
+                for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
+                    context.report({
+                        node: node,
+                        messageId: "unexpectedGlobalExpect"
+                    });
+                }
             }
         };
     }

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const utils = require("../utils");
+const { ReferenceTracker } = require("eslint-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -28,13 +28,16 @@ module.exports = {
     },
 
     create: function (context) {
-        function isModuleOrTest(calleeNode) {
-            return utils.isModule(calleeNode) || utils.isTest(calleeNode);
-        }
-
         return {
-            "CallExpression[callee.type='Identifier']": function (node) {
-                if (isModuleOrTest(node.callee)) {
+            "Program": function () {
+                const tracker = new ReferenceTracker(context.getScope());
+                const traceMap = {
+                    asyncTest: { [ReferenceTracker.CALL]: true },
+                    module: { [ReferenceTracker.CALL]: true },
+                    test: { [ReferenceTracker.CALL]: true }
+                };
+
+                for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
                     context.report({
                         node: node,
                         messageId: "unexpectedGlobalModuleTest",

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -6,6 +6,8 @@
  */
 "use strict";
 
+const { ReferenceTracker } = require("eslint-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -29,14 +31,22 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            "CallExpression[callee.name=/^(stop|start)$/]": function (node) {
-                context.report({
-                    node: node,
-                    messageId: "unexpectedGlobalStopStart",
-                    data: {
-                        callee: node.callee.name
-                    }
-                });
+            "Program": function () {
+                const tracker = new ReferenceTracker(context.getScope());
+                const traceMap = {
+                    start: { [ReferenceTracker.CALL]: true },
+                    stop: { [ReferenceTracker.CALL]: true }
+                };
+
+                for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
+                    context.report({
+                        node: node,
+                        messageId: "unexpectedGlobalStopStart",
+                        data: {
+                            callee: node.callee.name
+                        }
+                    });
+                }
             }
         };
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,6 +59,12 @@ const ASSERTION_METADATA = {
     }
 };
 
+function getAssertionNames() {
+    return Object.keys(ASSERTION_METADATA);
+}
+
+exports.getAssertionNames = getAssertionNames;
+
 function getAssertionMetadata(calleeNode, assertVar) {
     if (calleeNode.type === "MemberExpression") {
         return calleeNode.object &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,19 +1270,17 @@
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
     },
     "espree": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "index.js",
     "lib/"
   ],
+  "dependencies": {
+    "eslint-utils": "^2.1.0"
+  },
   "devDependencies": {
     "all-contributors-cli": "^6.17.2",
     "chai": "^4.2.0",

--- a/tests/lib/rules/no-global-assertions.js
+++ b/tests/lib/rules/no-global-assertions.js
@@ -51,6 +51,12 @@ ruleTester.run("no-global-assertions", rule, {
         wrap("assert.throws(function () {}, TypeError);"),
         wrap("assert.expect(1);"),
 
+        // Global overridden by local import/declaration.
+        {
+            code: "var strictEqual = require('foo'); strictEqual();",
+            globals: { strictEqual: true }
+        },
+
         // Intentionally not covered by this rule
         wrap("expect(1);")
     ],
@@ -58,47 +64,58 @@ ruleTester.run("no-global-assertions", rule, {
     invalid: [
         {
             code: wrap("ok(true);"),
-            errors: [createError("ok")]
+            errors: [createError("ok")],
+            globals: { ok: true }
         },
         {
             code: wrap("equal(a, b);"),
-            errors: [createError("equal")]
+            errors: [createError("equal")],
+            globals: { equal: true }
         },
         {
             code: wrap("strictEqual(a, b);"),
-            errors: [createError("strictEqual")]
+            errors: [createError("strictEqual")],
+            globals: { strictEqual: true }
         },
         {
             code: wrap("deepEqual(a, b);"),
-            errors: [createError("deepEqual")]
+            errors: [createError("deepEqual")],
+            globals: { deepEqual: true }
         },
         {
             code: wrap("propEqual(a, b);"),
-            errors: [createError("propEqual")]
+            errors: [createError("propEqual")],
+            globals: { propEqual: true }
         },
         {
             code: wrap("notEqual(a, b);"),
-            errors: [createError("notEqual")]
+            errors: [createError("notEqual")],
+            globals: { notEqual: true }
         },
         {
             code: wrap("notStrictEqual(a, b);"),
-            errors: [createError("notStrictEqual")]
+            errors: [createError("notStrictEqual")],
+            globals: { notStrictEqual: true }
         },
         {
             code: wrap("notDeepEqual(a, b);"),
-            errors: [createError("notDeepEqual")]
+            errors: [createError("notDeepEqual")],
+            globals: { notDeepEqual: true }
         },
         {
             code: wrap("notPropEqual(a, b);"),
-            errors: [createError("notPropEqual")]
+            errors: [createError("notPropEqual")],
+            globals: { notPropEqual: true }
         },
         {
             code: wrap("raises(function () {}, TypeError);"),
-            errors: [createError("raises")]
+            errors: [createError("raises")],
+            globals: { raises: true }
         },
         {
             code: wrap("throws(function () {}, TypeError);"),
-            errors: [createError("throws")]
+            errors: [createError("throws")],
+            globals: { throws: true }
         }
     ]
 });

--- a/tests/lib/rules/no-global-expect.js
+++ b/tests/lib/rules/no-global-expect.js
@@ -23,11 +23,42 @@ function wrap(code) {
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: "module"
+    }
+});
 
 ruleTester.run("no-global-expect", rule, {
     valid: [
-        wrap("assert.expect(1);")
+        wrap("assert.expect(1);"),
+        {
+            code: wrap("assert.expect(1);"),
+            globals: { expect: true }
+        },
+
+        // Global overridden by local import/declaration.
+        {
+            code: `import expect from 'foo'; ${wrap("expect(1);")}`,
+            globals: { expect: true }
+        },
+        {
+            code: `import { expect } from 'foo'; ${wrap("expect(1);")}`,
+            globals: { expect: true }
+        },
+        {
+            code: `var expect = require('foo'); ${wrap("expect(1);")}`,
+            globals: { expect: true }
+        },
+        {
+            code: `var expect = () => {}; ${wrap("expect(1);")}`,
+            globals: { expect: true }
+        },
+        {
+            code: `function expect() {}; ${wrap("expect(1);")}`,
+            globals: { expect: true }
+        }
     ],
 
     invalid: [
@@ -36,7 +67,8 @@ ruleTester.run("no-global-expect", rule, {
             errors: [{
                 messageId: "unexpectedGlobalExpect",
                 type: "CallExpression"
-            }]
+            }],
+            globals: { expect: true }
         }
     ]
 });

--- a/tests/lib/rules/no-global-module-test.js
+++ b/tests/lib/rules/no-global-module-test.js
@@ -24,7 +24,13 @@ ruleTester.run("no-global-module-test", rule, {
         "QUnit.asyncTest();",
 
         // Other identifiers are perfectly valid
-        "ok();"
+        "ok();",
+
+        // Global overridden by local import/declaration.
+        {
+            code: "var module = require('foo'); module();",
+            globals: { module: true }
+        }
     ],
 
     invalid: [
@@ -36,7 +42,8 @@ ruleTester.run("no-global-module-test", rule, {
                     callee: "module"
                 },
                 type: "CallExpression"
-            }]
+            }],
+            globals: { module: true }
         },
         {
             code: "test();",
@@ -46,7 +53,8 @@ ruleTester.run("no-global-module-test", rule, {
                     callee: "test"
                 },
                 type: "CallExpression"
-            }]
+            }],
+            globals: { test: true }
         },
         {
             code: "asyncTest();",
@@ -56,7 +64,8 @@ ruleTester.run("no-global-module-test", rule, {
                     callee: "asyncTest"
                 },
                 type: "CallExpression"
-            }]
+            }],
+            globals: { asyncTest: true }
         }
     ]
 });

--- a/tests/lib/rules/no-global-stop-start.js
+++ b/tests/lib/rules/no-global-stop-start.js
@@ -23,7 +23,13 @@ ruleTester.run("no-global-stop-start", rule, {
 
     valid: [
         "QUnit.stop();",
-        "QUnit.start();"
+        "QUnit.start();",
+
+        // Global overridden by local import/declaration.
+        {
+            code: "var start = require('foo'); start();",
+            globals: { start: true }
+        }
     ],
 
     invalid: [
@@ -35,7 +41,8 @@ ruleTester.run("no-global-stop-start", rule, {
                     callee: "stop"
                 },
                 type: "CallExpression"
-            }]
+            }],
+            globals: { stop: true }
         },
         {
             code: "start();",
@@ -45,7 +52,8 @@ ruleTester.run("no-global-stop-start", rule, {
                     callee: "start"
                 },
                 type: "CallExpression"
-            }]
+            }],
+            globals: { start: true }
         }
     ]
 });


### PR DESCRIPTION
Fixes #75.

Updates these rules to only detect true global usages of `module()`, `deepEqual()`, etc and not usages where these functions are imported or defined locally.

This is now a valid example whereas previously it had false positives:

```js
import { test } from 'ember-qunit';
import { module } from 'qunit';

module('foo', hooks => {
  test('bar', function(assert) {
    // ...
  });
});
```

Makes use of the eslint-utils [ReferenceTracker](https://eslint-utils.mysticatea.dev/api/scope-utils.html#referencetracker-class) class.

* [no-global-assertions](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-assertions.md)
* [no-global-expect](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-expect.md)
* [no-global-module-test](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-module-test.md)
* [no-global-stop-start](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-stop-start.md)