### PR TITLE
Ensure consistent rule descriptions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -165,6 +165,7 @@
         "eslint-plugin/prefer-output-null": "error",
         "eslint-plugin/prefer-placeholders": "error",
         "eslint-plugin/report-message-format": ["error", "^[A-Z].*\\.$"],
+        "eslint-plugin/require-meta-docs-description": "error",
         "eslint-plugin/require-meta-docs-url": ["error", {
             "pattern": "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/{{name}}.md"
         }],

--- a/docs/rules/assert-args.md
+++ b/docs/rules/assert-args.md
@@ -1,4 +1,4 @@
-# Ensure the correct number of assert arguments is used (assert-args)
+# Enforce that the correct number of assert arguments are used (assert-args)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/literal-compare-order.md
+++ b/docs/rules/literal-compare-order.md
@@ -1,4 +1,4 @@
-# Ensure comparison assertions have arguments in the right order (literal-compare-order)
+# Enforce comparison assertions have arguments in the right order (literal-compare-order)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-arrow-tests.md
+++ b/docs/rules/no-arrow-tests.md
@@ -1,4 +1,4 @@
-# Forbid arrow functions as QUnit test/module callbacks (no-arrow-tests)
+# Disallow arrow functions as QUnit test/module callbacks (no-arrow-tests)
 
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 

--- a/docs/rules/no-assert-equal.md
+++ b/docs/rules/no-assert-equal.md
@@ -1,4 +1,4 @@
-# Forbid the use of assert.equal (no-assert-equal)
+# Disallow the use of assert.equal (no-assert-equal)
 
 The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 

--- a/docs/rules/no-assert-logical-expression.md
+++ b/docs/rules/no-assert-logical-expression.md
@@ -1,4 +1,4 @@
-# Forbid binary logical expressions in assert arguments (no-assert-logical-expression)
+# Disallow binary logical expressions in assert arguments (no-assert-logical-expression)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-assert-ok.md
+++ b/docs/rules/no-assert-ok.md
@@ -1,4 +1,4 @@
-# Forbid the use of assert.ok/assert.notOk (no-assert-ok)
+# Disallow the use of assert.ok/assert.notOk (no-assert-ok)
 
 `assert.ok` and `assert.notOk` pass for any truthy/falsy argument. As [many expressions evaluate to true/false in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) the usage of `assert.ok` is potentially error prone. In general, it should be advisable to always test for exact values in tests which makes tests a lot more solid.
 

--- a/docs/rules/no-async-in-loops.md
+++ b/docs/rules/no-async-in-loops.md
@@ -1,4 +1,4 @@
-# Forbid async calls in loops (no-async-in-loops)
+# Disallow async calls in loops (no-async-in-loops)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-async-test.md
+++ b/docs/rules/no-async-test.md
@@ -1,4 +1,4 @@
-# Forbid the use of asyncTest or QUnit.asyncTest (no-async-test)
+# Disallow the use of asyncTest or QUnit.asyncTest (no-async-test)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-commented-tests.md
+++ b/docs/rules/no-commented-tests.md
@@ -1,4 +1,4 @@
-# Forbid commented tests (no-commented-tests)
+# Disallow commented tests (no-commented-tests)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-compare-relation-boolean.md
+++ b/docs/rules/no-compare-relation-boolean.md
@@ -1,4 +1,4 @@
-# forbid comparing relational expression to boolean in assertions (no-compare-relation-boolean)
+# Disallow comparing relational expressions to booleans in assertions (no-compare-relation-boolean)
 
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 

--- a/docs/rules/no-conditional-assertions.md
+++ b/docs/rules/no-conditional-assertions.md
@@ -1,4 +1,4 @@
-# Forbid assertions within if statements or conditional expressions (no-conditional-assertions)
+# Disallow assertions within if statements or conditional expressions (no-conditional-assertions)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-early-return.md
+++ b/docs/rules/no-early-return.md
@@ -1,4 +1,4 @@
-# prevent early return in a QUnit test (no-early-return)
+# Disallow early return in tests (no-early-return)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-global-assertions.md
+++ b/docs/rules/no-global-assertions.md
@@ -1,4 +1,4 @@
-# Forbid the use of global QUnit assertions (no-global-assertions)
+# Disallow global QUnit assertions (no-global-assertions)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-global-expect.md
+++ b/docs/rules/no-global-expect.md
@@ -1,4 +1,4 @@
-# Forbid the use of global expect (no-global-expect)
+# Disallow global expect (no-global-expect)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-global-module-test.md
+++ b/docs/rules/no-global-module-test.md
@@ -1,4 +1,4 @@
-# Forbid the use of global module/test/asyncTest (no-global-module-test)
+# Disallow global module/test/asyncTest (no-global-module-test)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-global-stop-start.md
+++ b/docs/rules/no-global-stop-start.md
@@ -1,4 +1,4 @@
-# Forbid use of global stop()/start() (no-global-stop-start)
+# Disallow global stop/start (no-global-stop-start)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-identical-names.md
+++ b/docs/rules/no-identical-names.md
@@ -1,4 +1,4 @@
-# Forbid identical test and module names (no-identical-names)
+# Disallow identical test and module names (no-identical-names)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-init.md
+++ b/docs/rules/no-init.md
@@ -1,4 +1,4 @@
-# Forbids use of QUnit.init (no-init)
+# Disallow use of QUnit.init (no-init)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-jsdump.md
+++ b/docs/rules/no-jsdump.md
@@ -1,4 +1,4 @@
-# Forbid use of QUnit.jsDump() (no-jsdump)
+# Disallow use of QUnit.jsDump (no-jsdump)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -1,4 +1,4 @@
-# Forbid the use of assert.equal/assert.notEqual/assert.ok/assert.notOk (no-loose-assertions)
+# Disallow the use of assert.equal/assert.ok/assert.notEqual/assert.notOk (no-loose-assertions)
 
 The `assert.equal`/`assert.notEqual` assertion methods in QUnit use loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual`/`assert.notStrictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
 

--- a/docs/rules/no-negated-ok.md
+++ b/docs/rules/no-negated-ok.md
@@ -1,4 +1,4 @@
-# Forbid the use of negations in assert.ok/notOk (no-negated-ok)
+# Disallow negation in assert.ok/assert.notOk (no-negated-ok)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -1,4 +1,4 @@
-# Forbid QUnit.test() calls inside callback of another QUnit.test (no-nested-tests)
+# Disallow nested QUnit.test() calls (no-nested-tests)
 
 This rule prevents from incorrect usage of [Nested Scope](https://github.com/qunitjs/qunit/blob/master/docs/QUnit/module.md#nested-scope). Developer can write nested test instead of nested module by mistake. In this case test will still be executed, but effects may be unexpected.
 

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -1,4 +1,4 @@
-# Forbid equality comparisons in assert.ok/assert.notOk (no-ok-equality)
+# Disallow equality comparisons in assert.ok/assert.notOk (no-ok-equality)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-only.md
+++ b/docs/rules/no-only.md
@@ -1,4 +1,4 @@
-# Forbid the use of QUnit.only (no-only)
+# Disallow QUnit.only (no-only)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-qunit-push.md
+++ b/docs/rules/no-qunit-push.md
@@ -1,4 +1,4 @@
-# Forbid the use of QUnit.push (no-qunit-push)
+# Disallow QUnit.push (no-qunit-push)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-qunit-start-in-tests.md
+++ b/docs/rules/no-qunit-start-in-tests.md
@@ -1,4 +1,4 @@
-# Forbid QUnit.start() within tests or test hooks (no-qunit-start-in-tests)
+# Disallow QUnit.start() within tests or test hooks (no-qunit-start-in-tests)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-qunit-stop.md
+++ b/docs/rules/no-qunit-stop.md
@@ -1,4 +1,4 @@
-# Forbid the use of QUnit.stop (no-qunit-stop)
+# Disallow QUnit.stop (no-qunit-stop)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-reassign-log-callbacks.md
+++ b/docs/rules/no-reassign-log-callbacks.md
@@ -1,4 +1,4 @@
-# Forbid overwriting of QUnit logging callbacks (no-reassign-log-callbacks)
+# Disallow overwriting of QUnit logging callbacks (no-reassign-log-callbacks)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-reset.md
+++ b/docs/rules/no-reset.md
@@ -1,4 +1,4 @@
-# Forbids use of QUnit.reset (no-reset)
+# Disallow QUnit.reset (no-reset)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-setup-teardown.md
+++ b/docs/rules/no-setup-teardown.md
@@ -1,4 +1,4 @@
-# Forbid setup/teardown module hooks (no-setup-teardown)
+# Disallow setup/teardown module hooks (no-setup-teardown)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-skip.md
+++ b/docs/rules/no-skip.md
@@ -1,4 +1,4 @@
-# Forbid the use of QUnit.skip (no-skip)
+# Disallow QUnit.skip (no-skip)
 
 `QUnit.skip` is useful to mark a test as skipped. This should be preferred over commenting out the test. However, leaving tests skipped in perpetuity is a bad practice, as the test ceases to provide any use in ensuring correctness of your code. Skipping tests should be done sparingly.
 

--- a/docs/rules/no-test-expect-argument.md
+++ b/docs/rules/no-test-expect-argument.md
@@ -1,4 +1,4 @@
-# forbid expect argument in QUnit.test (no-test-expect-argument)
+# Disallow the expect argument in QUnit.test (no-test-expect-argument)
 
 :two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
 

--- a/docs/rules/no-throws-string.md
+++ b/docs/rules/no-throws-string.md
@@ -1,4 +1,4 @@
-# forbid assert.throws() with block, string, and message (no-throws-string)
+# Disallow assert.throws() with block, string, and message args (no-throws-string)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -1,4 +1,4 @@
-# Ensure that `expect` is called (require-expect)
+# Enforce that `expect` is called (require-expect)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/docs/rules/resolve-async.md
+++ b/docs/rules/resolve-async.md
@@ -1,4 +1,4 @@
-# Require that all async calls should be resolved in tests (resolve-async)
+# Require that async calls are resolved (resolve-async)
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
         "no-identical-names": require("./lib/rules/no-identical-names"),
         "no-init": require("./lib/rules/no-init"),
         "no-jsdump": require("./lib/rules/no-jsdump"),
-        "no-loose-assertions": require("./lib/rules/no-assert-ok"),
+        "no-loose-assertions": require("./lib/rules/no-loose-assertions"),
         "no-negated-ok": require("./lib/rules/no-negated-ok"),
         "no-nested-tests": require("./lib/rules/no-nested-tests"),
         "no-ok-equality": require("./lib/rules/no-ok-equality"),

--- a/lib/rules/assert-args.js
+++ b/lib/rules/assert-args.js
@@ -18,7 +18,7 @@ const assert = require("assert"),
 module.exports = {
     meta: {
         docs: {
-            description: "ensure correct number of assert arguments is used",
+            description: "enforce that the correct number of assert arguments are used",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md"
         },

--- a/lib/rules/literal-compare-order.js
+++ b/lib/rules/literal-compare-order.js
@@ -27,7 +27,7 @@ function swapFirstTwoNodesInList(sourceCode, fixer, list) {
 module.exports = {
     meta: {
         docs: {
-            description: "ensure comparison assertions have arguments in the right order",
+            description: "enforce comparison assertions have arguments in the right order",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/literal-compare-order.md"
         },

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -19,7 +19,7 @@ const utils = require("../utils.js");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid arrow functions as QUnit test/module callbacks",
+            description: "disallow arrow functions as QUnit test/module callbacks",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md"
         },

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -18,7 +18,7 @@ const assert = require("assert"),
 module.exports = {
     meta: {
         docs: {
-            description: "forbid the use of assert.equal",
+            description: "disallow the use of assert.equal",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md"
         },

--- a/lib/rules/no-assert-logical-expression.js
+++ b/lib/rules/no-assert-logical-expression.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid binary logical expressions in assert arguments",
+            description: "disallow binary logical expressions in assert arguments",
             category: "Best Practices",
             recommended: false,
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-logical-expression.md"

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -27,7 +27,7 @@ const ERROR_MESSAGE_CONFIG = {
 module.exports = {
     meta: {
         docs: {
-            description: "forbid the use of assert.ok/assert.notOk",
+            description: "disallow the use of assert.ok/assert.notOk",
             category: "Best Practices"
         },
         messages: {

--- a/lib/rules/no-async-in-loops.js
+++ b/lib/rules/no-async-in-loops.js
@@ -14,7 +14,7 @@ const assert = require("assert"),
 module.exports = {
     meta: {
         docs: {
-            description: "forbid async calls in loops",
+            description: "disallow async calls in loops",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-in-loops.md"
         },

--- a/lib/rules/no-async-test.js
+++ b/lib/rules/no-async-test.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid the use of asyncTest or QUnit.asyncTest",
+            description: "disallow the use of asyncTest or QUnit.asyncTest",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-test.md"
         },

--- a/lib/rules/no-commented-tests.js
+++ b/lib/rules/no-commented-tests.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "forbid commented tests",
+            description: "disallow commented tests",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-commented-tests.md"
         },

--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -18,7 +18,7 @@ const assert = require("assert"),
 module.exports = {
     meta: {
         docs: {
-            description: "forbid comparing relational expression to boolean in assertions",
+            description: "disallow comparing relational expressions to booleans in assertions",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-compare-relation-boolean.md"
         },

--- a/lib/rules/no-conditional-assertions.js
+++ b/lib/rules/no-conditional-assertions.js
@@ -29,7 +29,7 @@ const STOP_NODE_TYPES = [
 module.exports = {
     meta: {
         docs: {
-            description: "forbid assertions within if statements or conditional expressions",
+            description: "disallow assertions within if statements or conditional expressions",
             category: "Best Practices",
             recommended: false,
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-conditional-assertions.md"

--- a/lib/rules/no-early-return.js
+++ b/lib/rules/no-early-return.js
@@ -18,7 +18,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "prevent early return in a QUnit test",
+            description: "disallow early return in tests",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-early-return.md"
         },

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -18,7 +18,7 @@ const { ReferenceTracker } = require("eslint-utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid global QUnit assertions",
+            description: "disallow global QUnit assertions",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-assertions.md"
         },

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -17,7 +17,7 @@ const { ReferenceTracker } = require("eslint-utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid global expect",
+            description: "disallow global expect",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-expect.md"
         },

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -17,7 +17,7 @@ const { ReferenceTracker } = require("eslint-utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid global module/test/asyncTest",
+            description: "disallow global module/test/asyncTest",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-module-test.md"
         },

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -15,7 +15,7 @@ const { ReferenceTracker } = require("eslint-utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid global stop/start",
+            description: "disallow global stop/start",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-stop-start.md"
         },

--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -22,7 +22,7 @@ function areArraysEqual(arr1, arr2) {
 module.exports = {
     meta: {
         docs: {
-            description: "Forbid identical test and module names",
+            description: "disallow identical test and module names",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-identical-names.md"
         },

--- a/lib/rules/no-init.js
+++ b/lib/rules/no-init.js
@@ -13,7 +13,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "forbid use of QUnit.init",
+            description: "disallow use of QUnit.init",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-init.md"
         },

--- a/lib/rules/no-jsdump.js
+++ b/lib/rules/no-jsdump.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "forbid use of QUnit.jsDump",
+            description: "disallow use of QUnit.jsDump",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-jsdump.md"
         },

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -67,7 +67,7 @@ function parseOptions(options) {
 module.exports = {
     meta: {
         docs: {
-            description: "forbid the use of assert.equal/assert.ok/assert.notEqual/assert.notOk (can be configured)",
+            description: "disallow the use of assert.equal/assert.ok/assert.notEqual/assert.notOk",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-loose-assertions.md"
         },

--- a/lib/rules/no-negated-ok.js
+++ b/lib/rules/no-negated-ok.js
@@ -14,7 +14,7 @@ const assert = require("assert"),
 module.exports = {
     meta: {
         docs: {
-            description: "forbid negation in assert.ok/assert.notOk",
+            description: "disallow negation in assert.ok/assert.notOk",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-negated-ok.md"
         },

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "Forbid nested QUnit.test() calls",
+            description: "disallow nested QUnit.test() calls",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-nested-tests.md"
         },

--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -13,7 +13,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid equality comparisons in assert.ok/assert.notOk",
+            description: "disallow equality comparisons in assert.ok/assert.notOk",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-ok-equality.md"
         },

--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid QUnit.only",
+            description: "disallow QUnit.only",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-only.md"
         },

--- a/lib/rules/no-qunit-push.js
+++ b/lib/rules/no-qunit-push.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "forbid QUnit.push",
+            description: "disallow QUnit.push",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-push.md"
         },

--- a/lib/rules/no-qunit-start-in-tests.js
+++ b/lib/rules/no-qunit-start-in-tests.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid QUnit.start() within tests or test hooks",
+            description: "disallow QUnit.start() within tests or test hooks",
             category: "Possible Errors",
             recommended: false,
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-start-in-tests.md"

--- a/lib/rules/no-qunit-stop.js
+++ b/lib/rules/no-qunit-stop.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "Forbid QUnit.stop",
+            description: "disallow QUnit.stop",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-stop.md"
         },

--- a/lib/rules/no-reassign-log-callbacks.js
+++ b/lib/rules/no-reassign-log-callbacks.js
@@ -13,7 +13,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Forbid overwriting of QUnit logging callbacks",
+            description: "disallow overwriting of QUnit logging callbacks",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-reassign-log-callbacks.md"
         },

--- a/lib/rules/no-reset.js
+++ b/lib/rules/no-reset.js
@@ -13,7 +13,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "forbid QUnit.reset",
+            description: "disallow QUnit.reset",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-reset.md"
         },

--- a/lib/rules/no-setup-teardown.js
+++ b/lib/rules/no-setup-teardown.js
@@ -15,7 +15,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid setup/teardown module hooks",
+            description: "disallow setup/teardown module hooks",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-setup-teardown.md"
         },

--- a/lib/rules/no-skip.js
+++ b/lib/rules/no-skip.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid QUnit.skip",
+            description: "disallow QUnit.skip",
             category: "Best Practices",
             recommended: false,
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-skip.md"

--- a/lib/rules/no-test-expect-argument.js
+++ b/lib/rules/no-test-expect-argument.js
@@ -17,7 +17,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "forbid expect argument in QUnit.test",
+            description: "disallow the expect argument in QUnit.test",
             category: "Possible Errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-test-expect-argument.md"
         },

--- a/lib/rules/no-throws-string.js
+++ b/lib/rules/no-throws-string.js
@@ -44,7 +44,7 @@ function isThrows(calleeNode, assertVar) {
 module.exports = {
     meta: {
         docs: {
-            description: "forbid assert.throws() with block, string, and message args",
+            description: "disallow assert.throws() with block, string, and message args",
             category: "Possible errors",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-throws-string.md"
         },

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -14,7 +14,7 @@ const utils = require("../utils");
 module.exports = {
     meta: {
         docs: {
-            description: "ensure that expect is called",
+            description: "enforce that `expect` is called",
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/require-expect.md"
         },

--- a/tests/index.js
+++ b/tests/index.js
@@ -23,6 +23,15 @@ const MESSAGES = {
     configTwo: ":two: The `\"extends\": \"plugin:qunit/two\"` property in a configuration file enables this rule."
 };
 
+function toSentenceCase(str) {
+    return str.replace(
+        /^\w/,
+        function (txt) {
+            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+        }
+    );
+}
+
 describe("index.js", function () {
     let ruleFileNames;
 
@@ -67,8 +76,9 @@ describe("index.js", function () {
                     const lines = fileContents.split("\n");
 
                     // First content should be title.
-                    const titleRegexp = new RegExp(`^# .+ \\(${fileName}\\)$`);
-                    assert.ok(titleRegexp.test(lines[0]), "includes rule name in title header");
+                    const description = index.rules[fileName].meta.docs.description;
+                    const expectedTitle = `# ${toSentenceCase(description)} (${fileName})`;
+                    assert.equal(lines[0], expectedTitle, "includes the rule description and name in title");
 
                     // Decide which notices should be shown at the top of the doc.
                     const expectedNotices = [];


### PR DESCRIPTION
Enforces with this lint rule:

https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-docs-description.md