### PR TITLE
Fix false positive for tests in different modules in `no-identical-names` rule

### DIFF
--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -14,6 +14,10 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+function findLast(arr, callback) {
+    return arr.slice().reverse().find(callback);
+}
+
 module.exports = {
     meta: {
         type: "suggestion",
@@ -51,7 +55,7 @@ module.exports = {
             const parentModule = mapModuleNodeToInfo.get(modulesStack[modulesStack.length - 1]);
             if (parentModule.modules.length > 0) {
                 // Find the last function-less module at the current level if one exists, i.e: module('foo');
-                const lastFunctionLessModule = parentModule.modules.reverse().find(node => node.arguments.length === 1);
+                const lastFunctionLessModule = findLast(parentModule.modules, node => node.arguments.length === 1);
                 if (lastFunctionLessModule) {
                     return lastFunctionLessModule;
                 }

--- a/tests/lib/rules/no-identical-names.js
+++ b/tests/lib/rules/no-identical-names.js
@@ -41,6 +41,17 @@ ruleTester.run("no-identical-title", rule, {
             test("it1", function() {});
         `,
         outdent`
+            module('A');
+
+            test('foo', function() {});
+            test('bar', function() {});
+
+            module('B');
+
+            test('foo', function() {});
+            test('bar', function() {});
+        `,
+        outdent`
             module("module1");
             module("module2");
         `,


### PR DESCRIPTION
The problem was that `reverse` was performing an in-place reversal of the modules array every time it was called, when it was only intended for assisting with finding the last matching element and was not supposed to modify the array.

Fixes #142.