### PR TITLE
Fix `requireindex` usage to use correct directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 const requireIndex = require("requireindex");
 
 module.exports = {
-    rules: requireIndex("./lib/rules"),
+    rules: requireIndex(`${__dirname}/lib/rules`),
 
     // eslint-disable-next-line sort-keys
     configs: {


### PR DESCRIPTION
There's an unreleased commit that switched the plugin to use requireindex for loading the rules: https://github.com/platinumazure/eslint-plugin-qunit/commit/d3e0440301971feab59505f3fa8cd6a6434bb77a. I noticed this broke the plugin for me.

eslint-plugin-qunit is included in a config in another linting plugin of mine. As a result, the requireindex call was checking the wrong current directory for lib/rules.

```
Oops! Something went wrong! :(

ESLint: 7.10.0

Error: Failed to load plugin 'qunit' declared in '.eslintrc.js » plugin:my-plugin/my-config': Cannot find module 'my-home-folder/eslint-plugin-qunit/lib'
Require stack:
- my-home-folder/eslint-plugin-qunit/node_modules/requireindex/index.js
- my-home-folder/eslint-plugin-qunit/index.js
- my-home-folder/my-repo/node_modules/eslint/lib/cli-engine/config-array-factory.js
- my-home-folder/my-repo/node_modules/eslint/lib/cli-engine/cascading-config-array-factory.js
- my-home-folder/my-repo/node_modules/eslint/lib/cli-engine/cli-engine.js
- my-home-folder/my-repo/node_modules/eslint/lib/eslint/eslint.js
- my-home-folder/my-repo/node_modules/eslint/lib/eslint/index.js
- my-home-folder/my-repo/node_modules/eslint/lib/cli.js
- my-home-folder/my-repo/node_modules/eslint/bin/eslint.js
Referenced from: my-home-folder/my-plugin/lib/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:1029:15)
    at Function.Module._load (internal/modules/cjs/loader.js:898:27)
    at Module.require (internal/modules/cjs/loader.js:1089:19)
    at require (my-home-folder/my-repo/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
    at my-home-folder/eslint-plugin-qunit/node_modules/requireindex/index.js:11:28
    at Array.forEach (<anonymous>)
    at module.exports (my-home-folder/eslint-plugin-qunit/node_modules/requireindex/index.js:9:15)
    at Object.<anonymous> (my-home-folder/eslint-plugin-qunit/index.js:13:12)
    at Module._compile (my-home-folder/my-repo/node_modules/v8-compile-cache/v8-compile-cache.js:194:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
error Command failed with exit code 2.
```