### PR TITLE
Fix detection of test-less modules in `no-identical-names` rule

### DIFF
--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -40,7 +40,8 @@ module.exports = {
         const mapModuleNodeToInfo = new Map();
         mapModuleNodeToInfo.set(TOP_LEVEL_MODULE_NODE, {
             modules: [], // Children module nodes.
-            tests: [] // Children test nodes.
+            tests: [], // Children test nodes.
+            hasNestedTests: false // Whether this module has tests nested inside it.
         });
 
         //----------------------------------------------------------------------
@@ -51,13 +52,18 @@ module.exports = {
             return node.arguments && node.arguments[0] && node.arguments[0].type === "Literal";
         }
 
+        function moduleHasNestedTests(node) {
+            const moduleInfo = mapModuleNodeToInfo.get(node);
+            return moduleInfo.tests.length > 0 || moduleInfo.modules.some(moduleNode => moduleHasNestedTests(moduleNode));
+        }
+
         function getCurrentModuleNode() {
             const parentModule = mapModuleNodeToInfo.get(modulesStack[modulesStack.length - 1]);
             if (parentModule.modules.length > 0) {
-                // Find the last function-less module at the current level if one exists, i.e: module('foo');
-                const lastFunctionLessModule = findLast(parentModule.modules, node => node.arguments.length === 1);
-                if (lastFunctionLessModule) {
-                    return lastFunctionLessModule;
+                // Find the last test-less module at the current level if one exists, i.e: module('foo');
+                const lastTestLessModule = findLast(parentModule.modules, node => !mapModuleNodeToInfo.get(node).hasNestedTests);
+                if (lastTestLessModule) {
+                    return lastTestLessModule;
                 }
             }
             return modulesStack[modulesStack.length - 1];
@@ -120,7 +126,8 @@ module.exports = {
                 modulesStack.push(node);
                 mapModuleNodeToInfo.set(node, {
                     modules: [],
-                    tests: []
+                    tests: [],
+                    hasNestedTests: false
                 });
                 currentModuleInfo.modules.push(node); // Add to parent module's list of children modules.
             }
@@ -144,6 +151,9 @@ module.exports = {
                 if (modulesStack.length > 0 && modulesStack[modulesStack.length - 1] === node) {
                     // Exiting a module so pop it from the stack.
                     modulesStack.pop();
+
+                    // Record if we saw any nested tests in this module.
+                    mapModuleNodeToInfo.get(node).hasNestedTests = moduleHasNestedTests(node);
                 }
             }
         };

--- a/tests/lib/rules/no-identical-names.js
+++ b/tests/lib/rules/no-identical-names.js
@@ -52,6 +52,19 @@ ruleTester.run("no-identical-title", rule, {
             test('bar', function() {});
         `,
         outdent`
+            module('A', {}); // Object with no tests
+            test('foo', function () {});
+            module('B', function () {}); // Function with no tests
+            test('foo', function () {});
+        `,
+        outdent`
+            module("name1", function() {
+                test('it1', function() {});
+                module("name2", function() {});
+                test('it1', function() {}); // Part of name2
+            });
+        `,
+        outdent`
             module("module1");
             module("module2");
         `,
@@ -206,20 +219,6 @@ ruleTester.run("no-identical-title", rule, {
         },
         {
             code: outdent `
-                module("module1", function() {});
-                test("it1", function() {});
-                module("module2", function() {});
-                test("it1", function() {});
-            `,
-            errors: [{
-                messageId: "duplicateTest",
-                data: { line: 2 },
-                column: 6,
-                line: 4
-            }]
-        },
-        {
-            code: outdent `
                 module("module1", function() {
                     module("module2", function() {
                         test("it", function() {});
@@ -232,6 +231,26 @@ ruleTester.run("no-identical-title", rule, {
                 data: { line: 3 },
                 column: 14,
                 line: 4
+            }]
+        },
+        {
+            code: outdent `
+                test("it", function() {});
+
+                // Module with test deep inside it.
+                module("module1", function() {
+                    module("module2", function() {
+                        test("it-deep", function() {});
+                    });
+                });
+
+                test("it", function() {});
+            `,
+            errors: [{
+                messageId: "duplicateTest",
+                data: { line: 1 },
+                column: 6,
+                line: 10
             }]
         },
         {
@@ -260,22 +279,6 @@ ruleTester.run("no-identical-title", rule, {
                 column: 12,
                 line: 2
             }]
-        },
-        {
-            code: outdent`
-                module("name1", function() {
-                    test('it1', function() {});
-                    module("name2", function() {});
-                    test('it1', function() {});
-                });
-            `,
-            errors: [{
-                messageId: "duplicateTest",
-                data: { line: 2 },
-                column: 10,
-                line: 4
-            }]
         }
-
     ]
 });


### PR DESCRIPTION
This PR fixes the detection of test-less modules. A module is considered test-less if it has no tests nested inside it. Sibling tests that come after a test-less module are considered part of the module.

Fixes this test case:

```js
module('A', {});
test('foo', function () {});
module('B', {});
test('foo', function () {});
```

CC: @asapach

Related to #143.