### PR TITLE
Require eslint 6+ as peer dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
     - run: npm test
     - run: npm run update && git diff --exit-code
     - run: npm install --save-dev eslint@6 && npm test
-    - run: npm install --save-dev eslint@5 && npm test
 
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "shelljs": "^0.8.4"
   },
   "peerDepencencies": {
-    "eslint": ">=4.15.0 <8.0.0"
+    "eslint": ">=6.0.0 <8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
ESLint 6 has been out since 2019-06 and requiring it will enable us to use more sophisticated eslint features.

https://eslint.org/docs/user-guide/migrating-to-6.0.0

This can be merged as part of the V6 release: #114