### PR TITLE
Drop Node 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
   },
   "homepage": "https://github.com/platinumazure/eslint-plugin-qunit",
   "engines": {
-    "node": "10.x || 12.x || 13.x || >=14.0.0"
+    "node": "10.x || 12.x || >=14.0.0"
   }
 }


### PR DESCRIPTION
Node 13 is an odd-numbered version that is end-of-life.

This can be merged as part of the V6 release: #114