### PR TITLE
Update `fixToNotOk` rule option default to true in `no-negated-ok` rule

### DIFF
--- a/docs/rules/no-negated-ok.md
+++ b/docs/rules/no-negated-ok.md
@@ -54,7 +54,7 @@ QUnit.test('test', function (assert) {
 
 This rule takes an optional object containing:
 
-* `fixToNotOk` (boolean, default: false): Whether the rule should autofix `assert.ok(!foo)` to `assert.notOk(foo)` ([notOk](https://api.qunitjs.com/assert/notOk/) was added in QUnit 1.18)
+* `fixToNotOk` (boolean, default: true): Whether the rule should autofix `assert.ok(!foo)` to `assert.notOk(foo)` ([notOk](https://api.qunitjs.com/assert/notOk/) was added in QUnit 1.18)
 
 ## When Not to Use It
 

--- a/lib/rules/no-negated-ok.js
+++ b/lib/rules/no-negated-ok.js
@@ -29,7 +29,7 @@ module.exports = {
                 properties: {
                     fixToNotOk: {
                         type: "boolean",
-                        default: false
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -38,7 +38,7 @@ module.exports = {
     },
 
     create: function (context) {
-        const fixToNotOk = context.options[0] && context.options[0].fixToNotOk;
+        const fixToNotOk = !context.options[0] || context.options[0].fixToNotOk;
 
         // Declare a stack in case of nested test cases (not currently supported
         // in QUnit).

--- a/tests/lib/rules/no-negated-ok.js
+++ b/tests/lib/rules/no-negated-ok.js
@@ -99,6 +99,7 @@ ruleTester.run("no-negated-ok", rule, {
         {
             code: wrap("assert.ok(!foo)"),
             output: wrap("assert.equal(foo, false)"),
+            options: [{ fixToNotOk: false }],
             errors: [createError("assert.ok")]
         },
         {
@@ -108,14 +109,29 @@ ruleTester.run("no-negated-ok", rule, {
             errors: [createError("assert.ok")]
         },
         {
+            // fixToNotOk = true (implicit since this is the option's default)
+            code: wrap("assert.ok(!foo)"),
+            output: wrap("assert.notOk(foo)"),
+            errors: [createError("assert.ok")]
+        },
+
+        // ok (with message)
+        {
             code: wrap("assert.ok(!foo, 'message')"),
             output: wrap("assert.equal(foo, false, 'message')"),
+            options: [{ fixToNotOk: false }],
             errors: [createError("assert.ok")]
         },
         {
             code: wrap("assert.ok(!foo, 'message')"),
             output: wrap("assert.notOk(foo, 'message')"),
             options: [{ fixToNotOk: true }],
+            errors: [createError("assert.ok")]
+        },
+        {
+            // fixToNotOk = true (implicit since this is the option's default)
+            code: wrap("assert.ok(!foo, 'message')"),
+            output: wrap("assert.notOk(foo, 'message')"),
             errors: [createError("assert.ok")]
         },
 
@@ -135,6 +151,7 @@ ruleTester.run("no-negated-ok", rule, {
         {
             code: wrap("assert.ok(!!!foo)"),
             output: wrap("assert.equal(foo, false)"),
+            options: [{ fixToNotOk: false }],
             errors: [createError("assert.ok")]
         },
         {
@@ -144,8 +161,17 @@ ruleTester.run("no-negated-ok", rule, {
             errors: [createError("assert.ok")]
         },
         {
+            // fixToNotOk = true (implicit since this is the option's default)
+            code: wrap("assert.ok(!!!foo)"),
+            output: wrap("assert.notOk(foo)"),
+            errors: [createError("assert.ok")]
+        },
+
+        // triple negation is not allowed (with message)
+        {
             code: wrap("assert.ok(!!!foo, 'message')"),
             output: wrap("assert.equal(foo, false, 'message')"),
+            options: [{ fixToNotOk: false }],
             errors: [createError("assert.ok")]
         },
         {
@@ -155,10 +181,13 @@ ruleTester.run("no-negated-ok", rule, {
             errors: [createError("assert.ok")]
         },
         {
+            // fixToNotOk = true (implicit since this is the option's default)
             code: wrap("assert.notOk(!!!foo)"),
             output: wrap("assert.ok(foo)"),
             errors: [createError("assert.notOk")]
         },
+
+        // triple negation is not allowed (with notOk)
         {
             code: wrap("assert.notOk(!!!foo, 'message')"),
             output: wrap("assert.ok(foo, 'message')"),


### PR DESCRIPTION
This can be merged as part of the V6 release: #114 (V6 will require QUnit 2+ which has `notOk`).