### PR TITLE
Update `fixToNotOk` rule option default to true in `no-compare-relation-boolean` rule

### DIFF
--- a/docs/rules/no-compare-relation-boolean.md
+++ b/docs/rules/no-compare-relation-boolean.md
@@ -47,7 +47,7 @@ assert.ok(a > b);
 
 This rule takes an optional object containing:
 
-* `fixToNotOk` (boolean, default: false): Whether the rule should autofix examples like `assert.equal(a === b, false)` to `assert.notOk(a === b)` ([notOk](https://api.qunitjs.com/assert/notOk/) was added in QUnit 1.18)
+* `fixToNotOk` (boolean, default: true): Whether the rule should autofix examples like `assert.equal(a === b, false)` to `assert.notOk(a === b)` ([notOk](https://api.qunitjs.com/assert/notOk/) was added in QUnit 1.18)
 
 ## When Not To Use It
 

--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -33,7 +33,7 @@ module.exports = {
                 properties: {
                     fixToNotOk: {
                         type: "boolean",
-                        default: false
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -42,7 +42,7 @@ module.exports = {
     },
 
     create: function (context) {
-        const fixToNotOk = context.options[0] && context.options[0].fixToNotOk;
+        const fixToNotOk = !context.options[0] || context.options[0].fixToNotOk;
 
         const testStack = [],
             RELATIONAL_OPS = [

--- a/tests/lib/rules/no-compare-relation-boolean.js
+++ b/tests/lib/rules/no-compare-relation-boolean.js
@@ -73,9 +73,9 @@ ruleTester.run("no-compare-relation-boolean", rule, {
             output: "assert.notOk(a === b);"
         },
         {
-            // No autofix when rule option `fixToNotOk` is off by default.
+            // fixToNotOk = true (implicit since this is the option's default)
             code: "assert.equal(a === b, false);",
-            output: null
+            output: "assert.notOk(a === b);"
         },
         {
             // No autofix when rule option `fixToNotOk` is off explicitly.


### PR DESCRIPTION
This can be merged as part of the V6 release: #114 (V6 will require QUnit 2+ which has `notOk`).