### PR TITLE
Merge `two` config into `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ ESLint plugin containing rules useful for QUnit tests.
 
 ## Configurations
 
-You can extend from these configurations in order to simplify manual configuration of plugin rules in your project.
+You can extend from a configuration in order to simplify manual configuration of plugin rules in your project.
 
-For more details on how to extend your configuration from one or both of these plugin configurations, please see the [ESLint plugin configuration documentation](http://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin).
+For more details on how to extend your configuration from a plugin configuration, please see the [ESLint plugin configuration documentation](http://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin).
 
 |     | Name | Description |
 | :-- | :--- | :---------- |
 | :white_check_mark: | recommended | This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. You can use this configuration by extending from `"plugin:qunit/recommended"` in your configuration file. |
-| :two: | two | This configuration includes rules which are useful for avoiding runtime errors or unexpected behavior in QUnit 2.0. You can use this configuration by extending from `"plugin:qunit/two"` in your configuration file. |
 
 ## Rules
 
@@ -39,33 +38,33 @@ Each rule has emojis denoting:
 |  | [no-assert-ok](./docs/rules/no-assert-ok.md) | disallow the use of assert.ok/assert.notOk|
 | :white_check_mark: | [no-async-in-loops](./docs/rules/no-async-in-loops.md) | disallow async calls in loops|
 |  | [no-async-module-callbacks](./docs/rules/no-async-module-callbacks.md) | disallow async module callbacks|
-| :two: | [no-async-test](./docs/rules/no-async-test.md) | disallow the use of asyncTest or QUnit.asyncTest|
+| :white_check_mark: | [no-async-test](./docs/rules/no-async-test.md) | disallow the use of asyncTest or QUnit.asyncTest|
 | :white_check_mark: | [no-commented-tests](./docs/rules/no-commented-tests.md) | disallow commented tests|
 | :wrench: | [no-compare-relation-boolean](./docs/rules/no-compare-relation-boolean.md) | disallow comparing relational expressions to booleans in assertions|
 | :white_check_mark: | [no-conditional-assertions](./docs/rules/no-conditional-assertions.md) | disallow assertions within if statements or conditional expressions|
 | :white_check_mark: | [no-early-return](./docs/rules/no-early-return.md) | disallow early return in tests|
-| :two: | [no-global-assertions](./docs/rules/no-global-assertions.md) | disallow global QUnit assertions|
-| :two: | [no-global-expect](./docs/rules/no-global-expect.md) | disallow global expect|
-| :two: | [no-global-module-test](./docs/rules/no-global-module-test.md) | disallow global module/test/asyncTest|
-| :two: | [no-global-stop-start](./docs/rules/no-global-stop-start.md) | disallow global stop/start|
+| :white_check_mark: | [no-global-assertions](./docs/rules/no-global-assertions.md) | disallow global QUnit assertions|
+| :white_check_mark: | [no-global-expect](./docs/rules/no-global-expect.md) | disallow global expect|
+| :white_check_mark: | [no-global-module-test](./docs/rules/no-global-module-test.md) | disallow global module/test/asyncTest|
+| :white_check_mark: | [no-global-stop-start](./docs/rules/no-global-stop-start.md) | disallow global stop/start|
 |  | [no-hooks-from-ancestor-modules](./docs/rules/no-hooks-from-ancestor-modules.md) | disallow the use of hooks from ancestor modules|
 | :white_check_mark: | [no-identical-names](./docs/rules/no-identical-names.md) | disallow identical test and module names|
-| :two: | [no-init](./docs/rules/no-init.md) | disallow use of QUnit.init|
-| :two: | [no-jsdump](./docs/rules/no-jsdump.md) | disallow use of QUnit.jsDump|
+| :white_check_mark: | [no-init](./docs/rules/no-init.md) | disallow use of QUnit.init|
+| :white_check_mark: | [no-jsdump](./docs/rules/no-jsdump.md) | disallow use of QUnit.jsDump|
 |  | [no-loose-assertions](./docs/rules/no-loose-assertions.md) | disallow the use of assert.equal/assert.ok/assert.notEqual/assert.notOk|
 | :white_check_mark::wrench: | [no-negated-ok](./docs/rules/no-negated-ok.md) | disallow negation in assert.ok/assert.notOk|
 |  | [no-nested-tests](./docs/rules/no-nested-tests.md) | disallow nested QUnit.test() calls|
 | :white_check_mark::wrench: | [no-ok-equality](./docs/rules/no-ok-equality.md) | disallow equality comparisons in assert.ok/assert.notOk|
 | :white_check_mark: | [no-only](./docs/rules/no-only.md) | disallow QUnit.only|
-| :two: | [no-qunit-push](./docs/rules/no-qunit-push.md) | disallow QUnit.push|
-| :two: | [no-qunit-start-in-tests](./docs/rules/no-qunit-start-in-tests.md) | disallow QUnit.start() within tests or test hooks|
-| :two: | [no-qunit-stop](./docs/rules/no-qunit-stop.md) | disallow QUnit.stop|
-| :white_check_mark::two: | [no-reassign-log-callbacks](./docs/rules/no-reassign-log-callbacks.md) | disallow overwriting of QUnit logging callbacks|
-| :white_check_mark::two: | [no-reset](./docs/rules/no-reset.md) | disallow QUnit.reset|
-| :two::wrench: | [no-setup-teardown](./docs/rules/no-setup-teardown.md) | disallow setup/teardown module hooks|
+| :white_check_mark: | [no-qunit-push](./docs/rules/no-qunit-push.md) | disallow QUnit.push|
+| :white_check_mark: | [no-qunit-start-in-tests](./docs/rules/no-qunit-start-in-tests.md) | disallow QUnit.start() within tests or test hooks|
+| :white_check_mark: | [no-qunit-stop](./docs/rules/no-qunit-stop.md) | disallow QUnit.stop|
+| :white_check_mark: | [no-reassign-log-callbacks](./docs/rules/no-reassign-log-callbacks.md) | disallow overwriting of QUnit logging callbacks|
+| :white_check_mark: | [no-reset](./docs/rules/no-reset.md) | disallow QUnit.reset|
+| :white_check_mark::wrench: | [no-setup-teardown](./docs/rules/no-setup-teardown.md) | disallow setup/teardown module hooks|
 |  | [no-skip](./docs/rules/no-skip.md) | disallow QUnit.skip|
-| :two: | [no-test-expect-argument](./docs/rules/no-test-expect-argument.md) | disallow the expect argument in QUnit.test|
-| :white_check_mark::two: | [no-throws-string](./docs/rules/no-throws-string.md) | disallow assert.throws() with block, string, and message args|
+| :white_check_mark: | [no-test-expect-argument](./docs/rules/no-test-expect-argument.md) | disallow the expect argument in QUnit.test|
+| :white_check_mark: | [no-throws-string](./docs/rules/no-throws-string.md) | disallow assert.throws() with block, string, and message args|
 | :white_check_mark: | [require-expect](./docs/rules/require-expect.md) | enforce that `expect` is called|
 |  | [require-object-in-propequal](./docs/rules/require-object-in-propequal.md) | enforce use of objects as expected value in `assert.propEqual`|
 | :white_check_mark: | [resolve-async](./docs/rules/resolve-async.md) | require that async calls are resolved|

--- a/docs/rules/no-async-test.md
+++ b/docs/rules/no-async-test.md
@@ -1,6 +1,6 @@
 # Disallow the use of asyncTest or QUnit.asyncTest (no-async-test)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating `QUnit.asyncTest()` in favor of `assert.async()` within tests. This rule will flag `asyncTest` and `QUnit.asyncTest` calls and recommend that you use `assert.async()` instead.
 

--- a/docs/rules/no-global-assertions.md
+++ b/docs/rules/no-global-assertions.md
@@ -1,6 +1,6 @@
 # Disallow global QUnit assertions (no-global-assertions)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing global QUnit assertions such as `ok()`, requiring consumers to instead use scoped assertions provided on the test callback argument.
 

--- a/docs/rules/no-global-expect.md
+++ b/docs/rules/no-global-expect.md
@@ -1,6 +1,6 @@
 # Disallow global expect (no-global-expect)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing the global `expect` function. This rule will warn when the global `expect` function is used.
 

--- a/docs/rules/no-global-module-test.md
+++ b/docs/rules/no-global-module-test.md
@@ -1,6 +1,6 @@
 # Disallow global module/test/asyncTest (no-global-module-test)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing global functions related to declaring tests and modules. This rule will warn when the global functions are used.
 

--- a/docs/rules/no-global-stop-start.md
+++ b/docs/rules/no-global-stop-start.md
@@ -1,6 +1,6 @@
 # Disallow global stop/start (no-global-stop-start)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing all of its global exports, including
 `stop()` and `start()`.

--- a/docs/rules/no-init.md
+++ b/docs/rules/no-init.md
@@ -1,6 +1,6 @@
 # Disallow use of QUnit.init (no-init)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Early versions of QUnit exposed the `QUnit.init()` function, which allowed
 consumers to reinitialize the QUnit test runner. This has been discouraged for

--- a/docs/rules/no-jsdump.md
+++ b/docs/rules/no-jsdump.md
@@ -1,6 +1,6 @@
 # Disallow use of QUnit.jsDump (no-jsdump)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 When QUnit was first developed, it used the `jsDump` library for serializing
 objects as strings. Since then, QUnit has forked and evolved the library. To

--- a/docs/rules/no-qunit-push.md
+++ b/docs/rules/no-qunit-push.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.push (no-qunit-push)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 When writing custom assertions, the proper way to log an assertion result
 used to be calling `QUnit.push()` with the assertion result data. However, in

--- a/docs/rules/no-qunit-start-in-tests.md
+++ b/docs/rules/no-qunit-start-in-tests.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.start() within tests or test hooks (no-qunit-start-in-tests)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 The purpose of this rule is to ensure that `QUnit.start()` is not used within tests or test hooks.
 

--- a/docs/rules/no-qunit-stop.md
+++ b/docs/rules/no-qunit-stop.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.stop (no-qunit-stop)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit's handling of asynchronous tests used to be via tracking a global
 semaphore and not starting a test until the previous test had decremented the

--- a/docs/rules/no-reassign-log-callbacks.md
+++ b/docs/rules/no-reassign-log-callbacks.md
@@ -2,8 +2,6 @@
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
-
 In early versions of QUnit, it was possible to create logging functions that
 would be invoked as QUnit processed tests and modules by assigning to specific
 properties of the QUnit object. This became problematic when multiple logging

--- a/docs/rules/no-reset.md
+++ b/docs/rules/no-reset.md
@@ -2,8 +2,6 @@
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
-
 Early versions of QUnit exposed the `QUnit.reset()` function, which allowed
 consumers to invoke the internal QUnit fixture reset logic. This has been
 discouraged for a long time since QUnit now automatically invokes this method

--- a/docs/rules/no-setup-teardown.md
+++ b/docs/rules/no-setup-teardown.md
@@ -1,6 +1,6 @@
 # Disallow setup/teardown module hooks (no-setup-teardown)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 

--- a/docs/rules/no-test-expect-argument.md
+++ b/docs/rules/no-test-expect-argument.md
@@ -1,6 +1,6 @@
 # Disallow the expect argument in QUnit.test (no-test-expect-argument)
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating expect counts as the second argument of `QUnit.test`. Users are expected to use `assert.expect()` instead.
 

--- a/docs/rules/no-throws-string.md
+++ b/docs/rules/no-throws-string.md
@@ -2,8 +2,6 @@
 
 :white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:two: The `"extends": "plugin:qunit/two"` property in a configuration file enables this rule.
-
 QUnit 2.0 has deprecated the `assert.throws(block, string, message)` form of
 `assert.throws()`. This rule can be used to flag uses of the deprecated form
 and convert them to use a regular expression or some other predicate.

--- a/index.js
+++ b/index.js
@@ -21,30 +21,20 @@ module.exports = {
                 "qunit/literal-compare-order": "error",
                 "qunit/no-assert-logical-expression": "error",
                 "qunit/no-async-in-loops": "error",
+                "qunit/no-async-test": "error",
                 "qunit/no-commented-tests": "error",
                 "qunit/no-conditional-assertions": "error",
                 "qunit/no-early-return": "error",
-                "qunit/no-identical-names": "error",
-                "qunit/no-negated-ok": "error",
-                "qunit/no-ok-equality": "error",
-                "qunit/no-only": "error",
-                "qunit/no-reassign-log-callbacks": "error",
-                "qunit/no-reset": "error",
-                "qunit/no-throws-string": "error",
-                "qunit/require-expect": "error",
-                "qunit/resolve-async": "error"
-            }
-        },
-        two: {
-            plugins: ["qunit"],
-            rules: {
-                "qunit/no-async-test": "error",
                 "qunit/no-global-assertions": "error",
                 "qunit/no-global-expect": "error",
                 "qunit/no-global-module-test": "error",
                 "qunit/no-global-stop-start": "error",
+                "qunit/no-identical-names": "error",
                 "qunit/no-init": "error",
                 "qunit/no-jsdump": "error",
+                "qunit/no-negated-ok": "error",
+                "qunit/no-ok-equality": "error",
+                "qunit/no-only": "error",
                 "qunit/no-qunit-push": "error",
                 "qunit/no-qunit-start-in-tests": "error",
                 "qunit/no-qunit-stop": "error",
@@ -52,7 +42,9 @@ module.exports = {
                 "qunit/no-reset": "error",
                 "qunit/no-setup-teardown": "error",
                 "qunit/no-test-expect-argument": "error",
-                "qunit/no-throws-string": "error"
+                "qunit/no-throws-string": "error",
+                "qunit/require-expect": "error",
+                "qunit/resolve-async": "error"
             }
         }
     }

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -10,7 +10,6 @@ const tablePlaceholder = /<!--RULES_TABLE_START-->[\S\s]*<!--RULES_TABLE_END-->/
 
 // Config/preset/fixable emojis.
 const EMOJI_RECOMMENDED = ":white_check_mark:";
-const EMOJI_TWO = ":two:";
 const EMOJI_FIXABLE = ":wrench:";
 
 // Generate rule table contents.
@@ -19,12 +18,10 @@ const rulesTableContent = Object.keys(rules)
     .map((ruleName) => {
         // Check which emojis to show for this rule.
         const isRecommended = Object.prototype.hasOwnProperty.call(configs.recommended.rules, `qunit/${ruleName}`);
-        const isTwo = Object.prototype.hasOwnProperty.call(configs.two.rules, `qunit/${ruleName}`);
         const isFixable = rules[ruleName].meta.fixable;
 
         const emojis = [
             isRecommended ? EMOJI_RECOMMENDED : "",
-            isTwo ? EMOJI_TWO : "",
             isFixable ? EMOJI_FIXABLE : ""
         ].join("");
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -19,8 +19,7 @@ const assert = require("chai").assert,
 
 const MESSAGES = {
     fixable: ":wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.",
-    configRecommended: ":white_check_mark: The `\"extends\": \"plugin:qunit/recommended\"` property in a configuration file enables this rule.",
-    configTwo: ":two: The `\"extends\": \"plugin:qunit/two\"` property in a configuration file enables this rule."
+    configRecommended: ":white_check_mark: The `\"extends\": \"plugin:qunit/recommended\"` property in a configuration file enables this rule."
 };
 
 function toSentenceCase(str) {
@@ -87,11 +86,6 @@ describe("index.js", function () {
                         expectedNotices.push("configRecommended");
                     } else {
                         unexpectedNotices.push("configRecommended");
-                    }
-                    if (index.configs.two.rules[`qunit/${fileName}`]) {
-                        expectedNotices.push("configTwo");
-                    } else {
-                        unexpectedNotices.push("configTwo");
                     }
                     if (index.rules[fileName].meta.fixable) {
                         expectedNotices.push("fixable");


### PR DESCRIPTION
This can be merged as part of the V6 release: #114.

It would be easiest if we merged some other changes first then rebased this PR:

- [ ] Add more `recommended` rules for v6 #157
- [x] Update `require-expect` rule to default to `expect-simple` option #158 