### PR TITLE
Require QUnit 2+ as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "shelljs": "^0.8.4"
   },
   "peerDepencencies": {
-    "eslint": ">=4.15.0 <8.0.0"
+    "eslint": ">=4.15.0 <8.0.0",
+    "qunit": ">=2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This can be merged as part of the V6 release: #114.