### PR TITLE
Update `require-expect` rule to default to `expect-simple` option

### DIFF
--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -9,9 +9,11 @@ also calls `assert.expect(0)`. QUnit also has a [configuration
 option](https://api.qunitjs.com/QUnit.config/) to require `expect` for every
 test. This rule checks for `expect` at linting time.
 
-The "always" option (default) requires that `expect` is called in each test.
+## Options
 
-The "except-simple" option only requires an `expect` call when an assertion is
+The "always" option requires that `expect` is called in each test.
+
+The "except-simple" (**default**) option only requires an `expect` call when an assertion is
 called inside of a block or when `assert` is passed to another function. The
 rationale here is that by wrapping `assert` statements in conditional blocks
 or callbacks, developers are at risk of creating tests that incorrectly pass
@@ -30,7 +32,7 @@ be considered an error.
 
 ### always
 
-When using the default "always" option, each test needs an expect call. So the
+When using the "always" option, each test needs an expect call. So the
 following would warn.
 
 ```js
@@ -55,7 +57,7 @@ test('name', function() {
 
 ### except-simple
 
-When using the "except-simple" option, the following patterns are considered
+When using the **default** "except-simple" option, the following patterns are considered
 warnings.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
                 "qunit/no-reassign-log-callbacks": "error",
                 "qunit/no-reset": "error",
                 "qunit/no-throws-string": "error",
-                "qunit/require-expect": ["error", "except-simple"],
+                "qunit/require-expect": "error",
                 "qunit/resolve-async": "error"
             }
         },

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -209,9 +209,10 @@ module.exports = {
         };
 
         return {
+            "always": AlwaysStrategy,
             "except-simple": ExceptSimpleStrategy,
             "never": NeverStrategy,
             "never-except-zero": NeverExceptZeroStrategy
-        }[context.options[0]] || AlwaysStrategy;
+        }[context.options[0]] || ExceptSimpleStrategy;
     }
 };

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -52,25 +52,33 @@ ruleTester.run("require-expect", rule, {
         // default, calling expect is valid
         {
             code: "test('name', function(assert) { assert.expect(0) });",
-            options: []
+            options: [] // Defaults to except-simple
         },
 
         // default, using global expect
         {
             code: "test('name', function() { expect(0) });",
-            options: []
+            options: [] // Defaults to except-simple
         },
 
         // CallExpression without parent object throws no errors
         {
             code: "test('name', function(assert) { assert.expect(0); noParentObject() });",
-            options: []
+            options: [] // Defaults to except-simple
+        },
+        {
+            code: "test('name', function(assert) { assert.expect(0); noParentObject() });",
+            options: ["always"]
         },
 
         // assert at top of test context is ok
         {
             code: "test('name', function(assert) { assert.ok(true) });",
             options: ["except-simple"]
+        },
+        {
+            code: "test('name', function(assert) { assert.ok(true) });",
+            options: [] // Defaults to except-simple
         },
 
         // global assertion at top of test context is ok
@@ -129,10 +137,10 @@ ruleTester.run("require-expect", rule, {
     ],
 
     invalid: [
-        // default - make sure expect is identified correctly
+        // always - make sure expect is identified correctly
         {
             code: "test('name', function(assert) { other.assert.expect(0) });",
-            options: [],
+            options: ["always"],
             errors: [alwaysErrorMessage("assert.expect")]
         },
 
@@ -140,6 +148,11 @@ ruleTester.run("require-expect", rule, {
         {
             code: "test('name', function(assert) { while (false) { assert.ok(true) } });",
             options: ["except-simple"],
+            errors: [exceptSimpleErrorMessage("assert.expect")]
+        },
+        {
+            code: "test('name', function(assert) { while (false) { assert.ok(true) } });",
+            options: [], // Defaults to except-simple
             errors: [exceptSimpleErrorMessage("assert.expect")]
         },
 
@@ -282,21 +295,21 @@ ruleTester.run("require-expect", rule, {
         // "always" configration - simple case
         {
             code: "test('name', function(assert) { assert.ok(true) })",
-            options: [],
+            options: ["always"],
             errors: [alwaysErrorMessage("assert.expect")]
         },
 
         // "always" configration - global assertion
         {
             code: "test('name', function() { equal(1, 1) })",
-            options: [],
+            options: ["always"],
             errors: [alwaysErrorMessage("expect")]
         },
 
         // "always" configuration checking that "expect" is called on assert.
         {
             code: "test('name', function(assert) { other.expect(1); assert.ok(true); });",
-            options: [],
+            options: ["always"],
             errors: [alwaysErrorMessage("assert.expect")]
         },
 
@@ -311,14 +324,14 @@ ruleTester.run("require-expect", rule, {
                 "    });",
                 "});"
             ].join(returnAndIndent),
-            options: [],
+            options: ["always"],
             errors: [Object.assign(alwaysErrorMessage("assert.expect"), { line: 2 })]
         },
 
         // "always" configuration - multiple assert statements only report one error per test
         {
             code: "test('name', function(assert) { maybe(function() { assert.ok(true); assert.ok(true); }) });",
-            options: [],
+            options: ["always"],
             errors: [Object.assign(alwaysErrorMessage("assert.expect"), { column: 1 })]
         },
 


### PR DESCRIPTION
Why? Because the `recommended` config was manually enabling this rule with the `expect-simple` behavior, so we might as well make that the default behavior of the rule to reduce confusion and improve consistency.

This can be merged as part of the V6 release: #114.