### PR TITLE
Add automatic suggestions for `no-assert-equal` rule

### DIFF
--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -21,11 +21,15 @@ module.exports = {
         docs: {
             description: "disallow the use of assert.equal",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md"
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md",
+            suggestion: true
         },
         messages: {
             unexpectedGlobalEqual: "Unexpected equal. Use strictEqual, deepEqual, or propEqual.",
-            unexpectedAssertEqual: "Unexpected {{assertVar}}.equal. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
+            unexpectedAssertEqual: "Unexpected {{assertVar}}.equal. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual.",
+            switchToDeepEqual: "Switch to deepEqual.",
+            switchToPropEqual: "Switch to propEqual.",
+            switchToStrictEqual: "Switch to strictEqual."
         },
         schema: []
     },
@@ -69,7 +73,28 @@ module.exports = {
                 messageId: isGlobalEqual(node.callee) ? "unexpectedGlobalEqual" : "unexpectedAssertEqual",
                 data: {
                     assertVar
-                }
+                },
+                suggest: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        fix(fixer) {
+                            return fixer.replaceText(isGlobalEqual(node.callee) ? node.callee : node.callee.property, "deepEqual");
+                        }
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        fix(fixer) {
+                            return fixer.replaceText(isGlobalEqual(node.callee) ? node.callee : node.callee.property, "propEqual");
+                        }
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        fix(fixer) {
+                            return fixer.replaceText(isGlobalEqual(node.callee) ? node.callee : node.callee.property, "strictEqual");
+                        }
+                    }
+                ]
+
             });
         }
 

--- a/tests/lib/rules/no-assert-equal.js
+++ b/tests/lib/rules/no-assert-equal.js
@@ -41,26 +41,82 @@ ruleTester.run("no-assert-equal", rule, {
             code: "QUnit.test('Name', function (assert) { assert.equal(a, b); });",
             errors: [{
                 messageId: "unexpectedAssertEqual",
-                data: { assertVar: "assert" }
+                data: { assertVar: "assert" },
+                suggestions: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        output: "QUnit.test('Name', function (assert) { assert.deepEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        output: "QUnit.test('Name', function (assert) { assert.propEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        output: "QUnit.test('Name', function (assert) { assert.strictEqual(a, b); });"
+                    }
+                ]
             }]
         },
         {
             code: "QUnit.test('Name', function (foo) { foo.equal(a, b); });",
             errors: [{
                 messageId: "unexpectedAssertEqual",
-                data: { assertVar: "foo" }
+                data: { assertVar: "foo" },
+                suggestions: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        output: "QUnit.test('Name', function (foo) { foo.deepEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        output: "QUnit.test('Name', function (foo) { foo.propEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        output: "QUnit.test('Name', function (foo) { foo.strictEqual(a, b); });"
+                    }
+                ]
             }]
         },
         {
             code: "QUnit.test('Name', function (assert) { equal(a, b); });",
             errors: [{
-                messageId: "unexpectedGlobalEqual"
+                messageId: "unexpectedGlobalEqual",
+                suggestions: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        output: "QUnit.test('Name', function (assert) { deepEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        output: "QUnit.test('Name', function (assert) { propEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        output: "QUnit.test('Name', function (assert) { strictEqual(a, b); });"
+                    }
+                ]
             }]
         },
         {
             code: "QUnit.test('Name', function () { equal(a, b); });",
             errors: [{
-                messageId: "unexpectedGlobalEqual"
+                messageId: "unexpectedGlobalEqual",
+                suggestions: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        output: "QUnit.test('Name', function () { deepEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        output: "QUnit.test('Name', function () { propEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        output: "QUnit.test('Name', function () { strictEqual(a, b); });"
+                    }
+                ]
             }]
         }
     ]


### PR DESCRIPTION
Suggests 3 fixes that can be automatically applied for violations of this rule.

https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions

https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md