### PR TITLE
Fix typo of `deepEqual` assert name in `require-object-in-propequal` rule doc

### DIFF
--- a/docs/rules/require-object-in-propequal.md
+++ b/docs/rules/require-object-in-propequal.md
@@ -7,7 +7,7 @@ of two objects. If the expected value is a string or other non-object, the asser
 result can be unexpected.
 
 For string comparisons, `assert.strictEqual` should be used. For arrays,
-`assert.deepStrictEqual` should be used.
+`assert.deepEqual` should be used.
 
 ## Rule Details
 


### PR DESCRIPTION
`deepStrictEqual` does not exist in qunit (it only exists in Node). `deepEqual` is strict in qunit.

https://api.qunitjs.com/assert/deepEqual/