### PR TITLE
Ensure boolean assertions are not missed by several rules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,9 @@ const ASSERTION_METADATA = {
         allowedArities: [2],
         compareActualFirst: true
     },
+    false: {
+        allowedArities: [1]
+    },
     notDeepEqual: {
         allowedArities: [2],
         compareActualFirst: true
@@ -56,6 +59,9 @@ const ASSERTION_METADATA = {
     },
     throws: {
         allowedArities: [1, 2]
+    },
+    true: {
+        allowedArities: [1]
     }
 };
 

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -45,7 +45,7 @@ ruleTester.run("assert-args", rule, {
         wrap("assert.equal(obj[key], expected, key + ' value is true');"),
 
         // false
-        wrap("false(result);"),
+        wrap("assert.false(result);"),
         wrap("assert.false(result, 'Message');"),
 
         // strictEqual

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -46,7 +46,7 @@ ruleTester.run("assert-args", rule, {
 
         // false
         wrap("false(result);"),
-        wrap("false(result, 'Message');"),
+        wrap("assert.false(result, 'Message');"),
 
         // strictEqual
         wrap("strictEqual(result, expected);"),

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -104,7 +104,7 @@ ruleTester.run("assert-args", rule, {
 
         // true
         wrap("assert.true(result);"),
-        wrap("true(result, 'Message');"),
+        wrap("assert.true(result, 'Message');"),
 
         // notOk
         wrap("notOk(result);"),

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -103,7 +103,7 @@ ruleTester.run("assert-args", rule, {
         wrap("assert.throws(function () {}, TypeError, expectedMessage);"),
 
         // true
-        wrap("true(result);"),
+        wrap("assert.true(result);"),
         wrap("true(result, 'Message');"),
 
         // notOk

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -44,6 +44,10 @@ ruleTester.run("assert-args", rule, {
         wrap("assert.equal(result, expected, 'Message');"),
         wrap("assert.equal(obj[key], expected, key + ' value is true');"),
 
+        // false
+        wrap("false(result);"),
+        wrap("false(result, 'Message');"),
+
         // strictEqual
         wrap("strictEqual(result, expected);"),
         wrap("strictEqual(result, expected, 'Message');"),
@@ -97,6 +101,10 @@ ruleTester.run("assert-args", rule, {
         wrap("assert.throws(function () {}, /error/, 'Message');"),
         wrap("assert.throws(function () {}, 'Error', 'Message');"),
         wrap("assert.throws(function () {}, TypeError, expectedMessage);"),
+
+        // true
+        wrap("true(result);"),
+        wrap("true(result, 'Message');"),
 
         // notOk
         wrap("notOk(result);"),
@@ -275,6 +283,50 @@ ruleTester.run("assert-args", rule, {
                 data: {
                     callee: "assert.equal",
                     argCount: 4
+                }
+            }]
+        },
+
+        // false
+        {
+            code: wrap("assert.false();"),
+            errors: [{
+                messageId: "unexpectedArgCountNoMessage",
+                data: {
+                    callee: "assert.false",
+                    argCount: 0
+                }
+            }]
+        },
+        {
+            code: wrap("assert.false(a, b, 'Message');"),
+            errors: [{
+                messageId: "unexpectedArgCount",
+                data: {
+                    callee: "assert.false",
+                    argCount: 3
+                }
+            }]
+        },
+
+        // true
+        {
+            code: wrap("assert.true();"),
+            errors: [{
+                messageId: "unexpectedArgCountNoMessage",
+                data: {
+                    callee: "assert.true",
+                    argCount: 0
+                }
+            }]
+        },
+        {
+            code: wrap("assert.true(a, b, 'Message');"),
+            errors: [{
+                messageId: "unexpectedArgCount",
+                data: {
+                    callee: "assert.true",
+                    argCount: 3
                 }
             }]
         },

--- a/tests/lib/rules/no-assert-logical-expression.js
+++ b/tests/lib/rules/no-assert-logical-expression.js
@@ -30,6 +30,7 @@ ruleTester.run("no-assert-logical-expression", rule, {
         // Simple assertions
         wrap("assert.ok(foo);"),
         wrap("assert.equal(foo, bar);"),
+        wrap("assert.false(foo);"),
         wrap("assert.strictEqual(foo, bar);"),
         wrap("assert.deepEqual(foo, bar);"),
         wrap("assert.propEqual(foo, bar);"),
@@ -40,6 +41,7 @@ ruleTester.run("no-assert-logical-expression", rule, {
         wrap("assert.notPropEqual(foo, bar);"),
         wrap("assert.raises(function () {}, /Message/);"),
         wrap("assert.throws(function () {}, /Message/);"),
+        wrap("assert.true(foo);"),
 
         // Logical expressions inside raises/throw blocks are fine
         wrap("assert.raises(function () { throw (foo || bar); });"),
@@ -420,6 +422,32 @@ ruleTester.run("no-assert-logical-expression", rule, {
                 type: "LogicalExpression",
                 line: 1,
                 column: 72
+            }]
+        },
+
+        // Boolean assertions
+        {
+            code: wrap("assert.true(foo && bar);"),
+            errors: [{
+                messageId: "noLogicalOperator",
+                data: {
+                    operator: "&&"
+                },
+                type: "LogicalExpression",
+                line: 1,
+                column: 52
+            }]
+        },
+        {
+            code: wrap("assert.false(foo && bar);"),
+            errors: [{
+                messageId: "noLogicalOperator",
+                data: {
+                    operator: "&&"
+                },
+                type: "LogicalExpression",
+                line: 1,
+                column: 53
             }]
         }
     ]

--- a/tests/lib/rules/no-conditional-assertions.js
+++ b/tests/lib/rules/no-conditional-assertions.js
@@ -76,6 +76,7 @@ ruleTester.run("no-conditional-assertions", rule, {
     invalid: [
         "if (foo) assert.ok(true);",
         "if (foo) { assert.ok(true); }",
+        "if (foo) { assert.true(true); }",
         "if (foo) {} else if (bar) assert.ok(true);",
         "if (foo) {} else assert.ok(true);",
         "foo ? assert.ok(true) : false",

--- a/tests/lib/rules/no-global-assertions.js
+++ b/tests/lib/rules/no-global-assertions.js
@@ -40,6 +40,7 @@ ruleTester.run("no-global-assertions", rule, {
     valid: [
         wrap("assert.ok(true);"),
         wrap("assert.equal(a, b);"),
+        wrap("assert.false(foo);"),
         wrap("assert.strictEqual(a, b);"),
         wrap("assert.deepEqual(a, b);"),
         wrap("assert.propEqual(a, b);"),
@@ -49,6 +50,7 @@ ruleTester.run("no-global-assertions", rule, {
         wrap("assert.notPropEqual(a, b);"),
         wrap("assert.raises(function () {}, TypeError);"),
         wrap("assert.throws(function () {}, TypeError);"),
+        wrap("assert.true(foo);"),
         wrap("assert.expect(1);"),
 
         // Global overridden by local import/declaration.


### PR DESCRIPTION
Fixes #169. Adds the new boolean assertions (`true` and `false`) to our list of assertions so that they will be taken into account by several rules. Adds test cases to several rules.