### PR TITLE
Add `checkBooleanAssertions` option to `no-ok-equality` rule

### DIFF
--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -62,6 +62,13 @@ QUnit.test("Name", function (assert) { assert.ok(x instanceof Number); });
 
 ```
 
+## Configuration
+
+This rule takes an optional object containing:
+
+* `allowGlobals` (boolean, default: true): Whether the rule should check global assertions
+* `checkBooleanAssertions` (boolean, default: false): Whether the rule should check the [true](https://api.qunitjs.com/assert/true/) and [false](https://api.qunitjs.com/assert/false/) boolean assertions
+
 ## When Not to Use It
 
 It is best to enable this rule, but since it is possible to test a codebase

--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -28,6 +28,9 @@ module.exports = {
                 properties: {
                     allowGlobal: {
                         type: "boolean"
+                    },
+                    checkBooleanAssertions: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -40,10 +43,14 @@ module.exports = {
         // in QUnit).
         const asyncStateStack = [],
             DEFAULT_OPTIONS = {
-                allowGlobal: true
+                allowGlobal: true,
+                checkBooleanAssertions: false
             },
             options = context.options[0] || DEFAULT_OPTIONS,
             sourceCode = context.getSourceCode();
+
+        const POSITIVE_ASSERTIONS = options.checkBooleanAssertions ? ["ok", "true"] : ["ok"];
+        const NEGATIVE_ASSERTIONS = options.checkBooleanAssertions ? ["notOk", "false"] : ["notOk"];
 
         function getAssertContextVar() {
             const state = asyncStateStack[asyncStateStack.length - 1];
@@ -53,13 +60,13 @@ module.exports = {
         function isOk(calleeNode) {
             const assertContextVar = getAssertContextVar();
 
-            const isOk = calleeNode.type === "Identifier" && calleeNode.name === "ok";
+            const isOk = calleeNode.type === "Identifier" && POSITIVE_ASSERTIONS.includes(calleeNode.name);
 
             const isAssertOk = calleeNode.type === "MemberExpression" &&
                 calleeNode.object.type === "Identifier" &&
                 calleeNode.object.name === assertContextVar &&
                 calleeNode.property.type === "Identifier" &&
-                calleeNode.property.name === "ok";
+                POSITIVE_ASSERTIONS.includes(calleeNode.property.name);
 
             if (options.allowGlobal) {
                 return isOk || isAssertOk;
@@ -71,13 +78,13 @@ module.exports = {
         function isNotOk(calleeNode) {
             const assertContextVar = getAssertContextVar();
 
-            const isNotOk = calleeNode.type === "Identifier" && calleeNode.name === "notOk";
+            const isNotOk = calleeNode.type === "Identifier" && NEGATIVE_ASSERTIONS.includes(calleeNode.name);
 
             const isAssertNotOk = calleeNode.type === "MemberExpression" &&
                 calleeNode.object.type === "Identifier" &&
                 calleeNode.object.name === assertContextVar &&
                 calleeNode.property.type === "Identifier" &&
-                calleeNode.property.name === "notOk";
+                NEGATIVE_ASSERTIONS.includes(calleeNode.property.name);
 
             if (options.allowGlobal) {
                 return isNotOk || isAssertNotOk;

--- a/tests/lib/rules/no-ok-equality.js
+++ b/tests/lib/rules/no-ok-equality.js
@@ -79,6 +79,38 @@ ruleTester.run("no-ok-equality", rule, {
         {
             code: "test('Name', function () { notOk(x != 1); });",
             options: [{ allowGlobal: false }]
+        },
+
+        // Boolean assertions with no equality checks:
+        {
+            code: "test('Name', function (assert) { assert.true(x); });",
+            options: [{ checkBooleanAssertions: true }]
+        },
+        {
+            code: "test('Name', function (assert) { assert.true(x, 'message'); });",
+            options: [{ checkBooleanAssertions: true }]
+        },
+        {
+            code: "test('Name', function (assert) { assert.false(x); });",
+            options: [{ checkBooleanAssertions: true }]
+        },
+        {
+            code: "test('Name', function (assert) { assert.false(x, 'message'); });",
+            options: [{ checkBooleanAssertions: true }]
+        },
+
+        // Boolean assertions with equality checks (checkBooleanAssertions = false, implicitly)
+        "test('Name', function (assert) { assert.true(x === 1); });",
+        "test('Name', function (assert) { assert.false(x === 1); });",
+
+        // Boolean assertions with equality checks (checkBooleanAssertions = false, explicitly)
+        {
+            code: "test('Name', function (assert) { assert.true(x === 1); });",
+            options: [{ checkBooleanAssertions: false }]
+        },
+        {
+            code: "test('Name', function (assert) { assert.false(x === 1); });",
+            options: [{ checkBooleanAssertions: false }]
         }
     ],
 
@@ -209,6 +241,44 @@ ruleTester.run("no-ok-equality", rule, {
             options: [{ allowGlobal: true }],
             errors: [
                 createError("notOk", "equal", "x", "1")
+            ]
+        },
+
+        // Boolean assertions with equality checks (checkBooleanAssertions = true, explicitly)
+        {
+            // true
+            code: "test('Name', function (assert) { assert.true(x === 1); });",
+            output: "test('Name', function (assert) { assert.strictEqual(x, 1); });",
+            options: [{ checkBooleanAssertions: true }],
+            errors: [
+                createError("assert.true", "assert.strictEqual", "x", "1")
+            ]
+        },
+        {
+            // true, with message
+            code: "test('Name', function (assert) { assert.true(x === 1, 'message'); });",
+            output: "test('Name', function (assert) { assert.strictEqual(x, 1, 'message'); });",
+            options: [{ checkBooleanAssertions: true }],
+            errors: [
+                createError("assert.true", "assert.strictEqual", "x", "1")
+            ]
+        },
+        {
+            // false
+            code: "test('Name', function (assert) { assert.false(x === 1); });",
+            output: "test('Name', function (assert) { assert.notStrictEqual(x, 1); });",
+            options: [{ checkBooleanAssertions: true }],
+            errors: [
+                createError("assert.false", "assert.notStrictEqual", "x", "1")
+            ]
+        },
+        {
+            // false, with message
+            code: "test('Name', function (assert) { assert.false(x === 1, 'message'); });",
+            output: "test('Name', function (assert) { assert.notStrictEqual(x, 1, 'message'); });",
+            options: [{ checkBooleanAssertions: true }],
+            errors: [
+                createError("assert.false", "assert.notStrictEqual", "x", "1")
             ]
         }
     ]


### PR DESCRIPTION
This adds a new option `checkBooleanAssertions` to the rule [no-ok-equality](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-ok-equality.md).

The boolean assertions `true`/`false` are very similar to the `ok`/`notOk` assertions that are already checked by the rule.

Disallows and autofixes assertions like:

```js
assert.true(foo === 1);
assert.false(foo !== 1);
```

We can enable the `checkBooleanAssertions` option by default in the next major release.

Fixes #171.