### PR TITLE
Enable `indent` rule in markdown JS code samples

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -190,7 +190,6 @@
                 "brace-style": "off",
                 "eqeqeq": "off",
                 "guard-for-in": "off",
-                "indent": "off",
                 "no-constant-condition": "off",
                 "no-empty-function": "off",
                 "no-undef": "off",

--- a/docs/rules/no-assert-ok.md
+++ b/docs/rules/no-assert-ok.md
@@ -6,7 +6,7 @@ An example when using `assert.ok` can involuntarily go wrong:
 
 ```js
 test('test myFunc returns a truthy value', (assert) => {
-  assert.ok(myFunc);
+    assert.ok(myFunc);
 });
 ```
 

--- a/docs/rules/no-async-module-callbacks.md
+++ b/docs/rules/no-async-module-callbacks.md
@@ -12,15 +12,15 @@ if it was within the last `module` that QUnit processes.
 
 ```js
 QUnit.module('An async module', async function () {
-  QUnit.test('a passing test', function (assert) {
-    assert.ok(true);
-  });
+    QUnit.test('a passing test', function (assert) {
+        assert.ok(true);
+    });
 
-  await Promise.resolve();
+    await Promise.resolve();
 
-  QUnit.test('another passing test', function (assert) {
-    assert.ok(true);
-  });
+    QUnit.test('another passing test', function (assert) {
+        assert.ok(true);
+    });
 });
 
 QUnit.module('Some other module');

--- a/docs/rules/no-hooks-from-ancestor-modules.md
+++ b/docs/rules/no-hooks-from-ancestor-modules.md
@@ -15,15 +15,15 @@ The following patterns are considered warnings:
 
 ```js
 QUnit.module("outer module", function(hooks) {
-  QUnit.module("inner module", function() {
-    hooks.beforeEach(function() {});
-  });
+    QUnit.module("inner module", function() {
+        hooks.beforeEach(function() {});
+    });
 });
 
 QUnit.module("outer module", function(outerHooks) {
-  QUnit.module("inner module", function(innerHooks) {
-    outerHooks.beforeEach(function() {});
-  });
+    QUnit.module("inner module", function(innerHooks) {
+        outerHooks.beforeEach(function() {});
+    });
 });
 ```
 
@@ -31,7 +31,7 @@ The following patterns are not warnings:
 
 ```js
 QUnit.module("example module", function(hooks) {
-  hooks.beforeEach(function() {});
+    hooks.beforeEach(function() {});
 });
 ```
 

--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -8,7 +8,7 @@ An example when using `assert.ok` can involuntarily go wrong:
 
 ```js
 test('test myFunc returns a truthy value', (assert) => {
-  assert.ok(myFunc);
+    assert.ok(myFunc);
 });
 ```
 


### PR DESCRIPTION
Autofixed.

I think we should switch to prettier eventually though.

I tried autofixing other stylistic rules but they caused syntax errors oddly.

https://eslint.org/docs/rules/indent