### PR TITLE
Add eslint-plugin-mocha

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -217,6 +217,10 @@
                 "quotes": "off",
                 "space-before-function-paren": "off"
             }
+        },
+        {
+            "files": ["tests/**/*.js"],
+            "extends": ["plugin:mocha/recommended"]
         }
     ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - run: npm ci
     - run: npm test
     - run: npm run update && git diff --exit-code
-    - run: npm install --save-dev eslint@6 --save-dev eslint-plugin-unicorn@19 && npm run unit-test
+    - run: npm install --save-dev eslint@6 --save-dev eslint-plugin-unicorn@19 --save-dev eslint-plugin-mocha@6 && npm run unit-test
 
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-eslint-plugin": "^2.3.0",
         "eslint-plugin-markdown": "^2.0.1",
+        "eslint-plugin-mocha": "^8.1.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-unicorn": "^30.0.0",
         "markdownlint-cli": "^0.27.1",
@@ -1753,6 +1754,22 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
+      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.1.0",
+        "ramda": "^0.27.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-node": {
@@ -4528,6 +4545,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -7441,6 +7464,16 @@
         "unified": "^6.1.2"
       }
     },
+    "eslint-plugin-mocha": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
+      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.1.0",
+        "ramda": "^0.27.1"
+      }
+    },
     "eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -9536,6 +9569,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
     },
     "randombytes": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^2.3.0",
     "eslint-plugin-markdown": "^2.0.1",
+    "eslint-plugin-mocha": "^8.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^30.0.0",
     "markdownlint-cli": "^0.27.1",


### PR DESCRIPTION
I refactored the index.js test structure a bit to simplify things and help address these two rules:

* [mocha/no-nested-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-nested-tests.md) (we had `describe` nested inside `it`)
* [mocha/no-setup-in-describe](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md) (doesn't like function calls or member expressions inside `describe`)

Note: for our ESLint 6 CI test, we have to use an older version of eslint-plugin-mocha that is still compatible with ESLint 6.

https://github.com/lo1tuma/eslint-plugin-mocha