### PR TITLE
Use `meta.hasSuggestions` for suggestable rules to prepare for ESLint 8

### DIFF
--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -22,8 +22,7 @@ module.exports = {
         docs: {
             description: "disallow the use of assert.equal",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md",
-            suggestion: true
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md"
         },
         messages: {
             unexpectedGlobalEqual: "Unexpected equal. Use strictEqual, deepEqual, or propEqual.",
@@ -32,7 +31,8 @@ module.exports = {
             switchToPropEqual: "Switch to propEqual.",
             switchToStrictEqual: "Switch to strictEqual."
         },
-        schema: []
+        schema: [],
+        hasSuggestions: true
     },
 
     create: function (context) {


### PR DESCRIPTION
The change to require suggestable rules to have `meta.hasSuggestions` has been accepted and mentioned in the blog post for the upcoming ESLint 8 breaking changes. So we should adopt this change now to ensure we are compatible with ESLint 8 as soon as possible. The old property `meta.docs.suggestion` was unused anyway.

https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property