### PR TITLE
Breaking: Add `no-assert-equal` to `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each rule has emojis denoting:
 | [assert-args](./docs/rules/assert-args.md) | enforce that the correct number of assert arguments are used | ✅ |  |  |
 | [literal-compare-order](./docs/rules/literal-compare-order.md) | enforce comparison assertions have arguments in the right order | ✅ | 🔧 |  |
 | [no-arrow-tests](./docs/rules/no-arrow-tests.md) | disallow arrow functions as QUnit test/module callbacks | ✅ | 🔧 |  |
-| [no-assert-equal](./docs/rules/no-assert-equal.md) | disallow the use of assert.equal |  | ✅ | 💡 |
+| [no-assert-equal](./docs/rules/no-assert-equal.md) | disallow the use of assert.equal | ✅ |  | 💡 |
 | [no-assert-equal-boolean](./docs/rules/no-assert-equal-boolean.md) | require use of boolean assertions | ✅ | 🔧 |  |
 | [no-assert-logical-expression](./docs/rules/no-assert-logical-expression.md) | disallow binary logical expressions in assert arguments | ✅ |  |  |
 | [no-assert-ok](./docs/rules/no-assert-ok.md) | disallow the use of assert.ok/assert.notOk |  |  |  |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each rule has emojis denoting:
 | [assert-args](./docs/rules/assert-args.md) | enforce that the correct number of assert arguments are used | :white_check_mark: |  |  |
 | [literal-compare-order](./docs/rules/literal-compare-order.md) | enforce comparison assertions have arguments in the right order | :white_check_mark: | :wrench: |  |
 | [no-arrow-tests](./docs/rules/no-arrow-tests.md) | disallow arrow functions as QUnit test/module callbacks | :white_check_mark: | :wrench: |  |
-| [no-assert-equal](./docs/rules/no-assert-equal.md) | disallow the use of assert.equal |  |  | 💡 |
+| [no-assert-equal](./docs/rules/no-assert-equal.md) | disallow the use of assert.equal | :white_check_mark: |  | 💡 |
 | [no-assert-equal-boolean](./docs/rules/no-assert-equal-boolean.md) | require use of boolean assertions | :white_check_mark: | :wrench: |  |
 | [no-assert-logical-expression](./docs/rules/no-assert-logical-expression.md) | disallow binary logical expressions in assert arguments | :white_check_mark: |  |  |
 | [no-assert-ok](./docs/rules/no-assert-ok.md) | disallow the use of assert.ok/assert.notOk |  |  |  |

--- a/docs/rules/no-assert-equal.md
+++ b/docs/rules/no-assert-equal.md
@@ -1,5 +1,7 @@
 # Disallow the use of assert.equal (no-assert-equal)
 
+:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+
 💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.

--- a/docs/rules/no-assert-equal.md
+++ b/docs/rules/no-assert-equal.md
@@ -1,6 +1,6 @@
 # Disallow the use of assert.equal (no-assert-equal)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
                 "qunit/assert-args": "error",
                 "qunit/literal-compare-order": "error",
                 "qunit/no-arrow-tests": "error",
+                "qunit/no-assert-equal": "error",
                 "qunit/no-assert-equal-boolean": "error",
                 "qunit/no-assert-logical-expression": "error",
                 "qunit/no-async-in-loops": "error",


### PR DESCRIPTION
[no-assert-equal](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md)

Fixes #164.

Part of v7 release (https://github.com/platinumazure/eslint-plugin-qunit/projects/1, https://github.com/platinumazure/eslint-plugin-qunit/issues/175).