### PR TITLE
Switch from github emojis to standard emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,59 +16,59 @@ For more details on how to extend your configuration from a plugin configuration
 
 |     | Name | Description |
 | :-- | :--- | :---------- |
-| :white_check_mark: | recommended | This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. You can use this configuration by extending from `"plugin:qunit/recommended"` in your configuration file. |
+| ✅ | recommended | This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. You can use this configuration by extending from `"plugin:qunit/recommended"` in your configuration file. |
 
 ## Rules
 
 Each rule has emojis denoting:
 
 * What configuration it belongs to
-* :wrench: if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
+* 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
 * 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
 <!--RULES_TABLE_START-->
 
-| Name | Description | :white_check_mark: | :wrench: | 💡 |
+| Name | Description | ✅ | 🔧 | 💡 |
 |:--------|:--------|:---|:---|:---|
-| [assert-args](./docs/rules/assert-args.md) | enforce that the correct number of assert arguments are used | :white_check_mark: |  |  |
-| [literal-compare-order](./docs/rules/literal-compare-order.md) | enforce comparison assertions have arguments in the right order | :white_check_mark: | :wrench: |  |
-| [no-arrow-tests](./docs/rules/no-arrow-tests.md) | disallow arrow functions as QUnit test/module callbacks | :white_check_mark: | :wrench: |  |
+| [assert-args](./docs/rules/assert-args.md) | enforce that the correct number of assert arguments are used | ✅ |  |  |
+| [literal-compare-order](./docs/rules/literal-compare-order.md) | enforce comparison assertions have arguments in the right order | ✅ | 🔧 |  |
+| [no-arrow-tests](./docs/rules/no-arrow-tests.md) | disallow arrow functions as QUnit test/module callbacks | ✅ | 🔧 |  |
 | [no-assert-equal](./docs/rules/no-assert-equal.md) | disallow the use of assert.equal |  |  | 💡 |
-| [no-assert-equal-boolean](./docs/rules/no-assert-equal-boolean.md) | require use of boolean assertions | :white_check_mark: | :wrench: |  |
-| [no-assert-logical-expression](./docs/rules/no-assert-logical-expression.md) | disallow binary logical expressions in assert arguments | :white_check_mark: |  |  |
+| [no-assert-equal-boolean](./docs/rules/no-assert-equal-boolean.md) | require use of boolean assertions | ✅ | 🔧 |  |
+| [no-assert-logical-expression](./docs/rules/no-assert-logical-expression.md) | disallow binary logical expressions in assert arguments | ✅ |  |  |
 | [no-assert-ok](./docs/rules/no-assert-ok.md) | disallow the use of assert.ok/assert.notOk |  |  |  |
-| [no-async-in-loops](./docs/rules/no-async-in-loops.md) | disallow async calls in loops | :white_check_mark: |  |  |
-| [no-async-module-callbacks](./docs/rules/no-async-module-callbacks.md) | disallow async module callbacks | :white_check_mark: |  |  |
-| [no-async-test](./docs/rules/no-async-test.md) | disallow the use of asyncTest or QUnit.asyncTest | :white_check_mark: |  |  |
-| [no-commented-tests](./docs/rules/no-commented-tests.md) | disallow commented tests | :white_check_mark: |  |  |
-| [no-compare-relation-boolean](./docs/rules/no-compare-relation-boolean.md) | disallow comparing relational expressions to booleans in assertions | :white_check_mark: | :wrench: |  |
-| [no-conditional-assertions](./docs/rules/no-conditional-assertions.md) | disallow assertions within if statements or conditional expressions | :white_check_mark: |  |  |
-| [no-early-return](./docs/rules/no-early-return.md) | disallow early return in tests | :white_check_mark: |  |  |
-| [no-global-assertions](./docs/rules/no-global-assertions.md) | disallow global QUnit assertions | :white_check_mark: |  |  |
-| [no-global-expect](./docs/rules/no-global-expect.md) | disallow global expect | :white_check_mark: |  |  |
-| [no-global-module-test](./docs/rules/no-global-module-test.md) | disallow global module/test/asyncTest | :white_check_mark: |  |  |
-| [no-global-stop-start](./docs/rules/no-global-stop-start.md) | disallow global stop/start | :white_check_mark: |  |  |
-| [no-hooks-from-ancestor-modules](./docs/rules/no-hooks-from-ancestor-modules.md) | disallow the use of hooks from ancestor modules | :white_check_mark: |  |  |
-| [no-identical-names](./docs/rules/no-identical-names.md) | disallow identical test and module names | :white_check_mark: |  |  |
-| [no-init](./docs/rules/no-init.md) | disallow use of QUnit.init | :white_check_mark: |  |  |
-| [no-jsdump](./docs/rules/no-jsdump.md) | disallow use of QUnit.jsDump | :white_check_mark: |  |  |
+| [no-async-in-loops](./docs/rules/no-async-in-loops.md) | disallow async calls in loops | ✅ |  |  |
+| [no-async-module-callbacks](./docs/rules/no-async-module-callbacks.md) | disallow async module callbacks | ✅ |  |  |
+| [no-async-test](./docs/rules/no-async-test.md) | disallow the use of asyncTest or QUnit.asyncTest | ✅ |  |  |
+| [no-commented-tests](./docs/rules/no-commented-tests.md) | disallow commented tests | ✅ |  |  |
+| [no-compare-relation-boolean](./docs/rules/no-compare-relation-boolean.md) | disallow comparing relational expressions to booleans in assertions | ✅ | 🔧 |  |
+| [no-conditional-assertions](./docs/rules/no-conditional-assertions.md) | disallow assertions within if statements or conditional expressions | ✅ |  |  |
+| [no-early-return](./docs/rules/no-early-return.md) | disallow early return in tests | ✅ |  |  |
+| [no-global-assertions](./docs/rules/no-global-assertions.md) | disallow global QUnit assertions | ✅ |  |  |
+| [no-global-expect](./docs/rules/no-global-expect.md) | disallow global expect | ✅ |  |  |
+| [no-global-module-test](./docs/rules/no-global-module-test.md) | disallow global module/test/asyncTest | ✅ |  |  |
+| [no-global-stop-start](./docs/rules/no-global-stop-start.md) | disallow global stop/start | ✅ |  |  |
+| [no-hooks-from-ancestor-modules](./docs/rules/no-hooks-from-ancestor-modules.md) | disallow the use of hooks from ancestor modules | ✅ |  |  |
+| [no-identical-names](./docs/rules/no-identical-names.md) | disallow identical test and module names | ✅ |  |  |
+| [no-init](./docs/rules/no-init.md) | disallow use of QUnit.init | ✅ |  |  |
+| [no-jsdump](./docs/rules/no-jsdump.md) | disallow use of QUnit.jsDump | ✅ |  |  |
 | [no-loose-assertions](./docs/rules/no-loose-assertions.md) | disallow the use of assert.equal/assert.ok/assert.notEqual/assert.notOk |  |  |  |
-| [no-negated-ok](./docs/rules/no-negated-ok.md) | disallow negation in assert.ok/assert.notOk | :white_check_mark: | :wrench: |  |
-| [no-nested-tests](./docs/rules/no-nested-tests.md) | disallow nested QUnit.test() calls | :white_check_mark: |  |  |
-| [no-ok-equality](./docs/rules/no-ok-equality.md) | disallow equality comparisons in assert.ok/assert.notOk | :white_check_mark: | :wrench: |  |
-| [no-only](./docs/rules/no-only.md) | disallow QUnit.only | :white_check_mark: |  |  |
-| [no-qunit-push](./docs/rules/no-qunit-push.md) | disallow QUnit.push | :white_check_mark: |  |  |
-| [no-qunit-start-in-tests](./docs/rules/no-qunit-start-in-tests.md) | disallow QUnit.start() within tests or test hooks | :white_check_mark: |  |  |
-| [no-qunit-stop](./docs/rules/no-qunit-stop.md) | disallow QUnit.stop | :white_check_mark: |  |  |
-| [no-reassign-log-callbacks](./docs/rules/no-reassign-log-callbacks.md) | disallow overwriting of QUnit logging callbacks | :white_check_mark: |  |  |
-| [no-reset](./docs/rules/no-reset.md) | disallow QUnit.reset | :white_check_mark: |  |  |
-| [no-setup-teardown](./docs/rules/no-setup-teardown.md) | disallow setup/teardown module hooks | :white_check_mark: | :wrench: |  |
+| [no-negated-ok](./docs/rules/no-negated-ok.md) | disallow negation in assert.ok/assert.notOk | ✅ | 🔧 |  |
+| [no-nested-tests](./docs/rules/no-nested-tests.md) | disallow nested QUnit.test() calls | ✅ |  |  |
+| [no-ok-equality](./docs/rules/no-ok-equality.md) | disallow equality comparisons in assert.ok/assert.notOk | ✅ | 🔧 |  |
+| [no-only](./docs/rules/no-only.md) | disallow QUnit.only | ✅ |  |  |
+| [no-qunit-push](./docs/rules/no-qunit-push.md) | disallow QUnit.push | ✅ |  |  |
+| [no-qunit-start-in-tests](./docs/rules/no-qunit-start-in-tests.md) | disallow QUnit.start() within tests or test hooks | ✅ |  |  |
+| [no-qunit-stop](./docs/rules/no-qunit-stop.md) | disallow QUnit.stop | ✅ |  |  |
+| [no-reassign-log-callbacks](./docs/rules/no-reassign-log-callbacks.md) | disallow overwriting of QUnit logging callbacks | ✅ |  |  |
+| [no-reset](./docs/rules/no-reset.md) | disallow QUnit.reset | ✅ |  |  |
+| [no-setup-teardown](./docs/rules/no-setup-teardown.md) | disallow setup/teardown module hooks | ✅ | 🔧 |  |
 | [no-skip](./docs/rules/no-skip.md) | disallow QUnit.skip |  |  |  |
-| [no-test-expect-argument](./docs/rules/no-test-expect-argument.md) | disallow the expect argument in QUnit.test | :white_check_mark: |  |  |
-| [no-throws-string](./docs/rules/no-throws-string.md) | disallow assert.throws() with block, string, and message args | :white_check_mark: |  |  |
-| [require-expect](./docs/rules/require-expect.md) | enforce that `expect` is called | :white_check_mark: |  |  |
-| [require-object-in-propequal](./docs/rules/require-object-in-propequal.md) | enforce use of objects as expected value in `assert.propEqual` | :white_check_mark: |  |  |
-| [resolve-async](./docs/rules/resolve-async.md) | require that async calls are resolved | :white_check_mark: |  |  |
+| [no-test-expect-argument](./docs/rules/no-test-expect-argument.md) | disallow the expect argument in QUnit.test | ✅ |  |  |
+| [no-throws-string](./docs/rules/no-throws-string.md) | disallow assert.throws() with block, string, and message args | ✅ |  |  |
+| [require-expect](./docs/rules/require-expect.md) | enforce that `expect` is called | ✅ |  |  |
+| [require-object-in-propequal](./docs/rules/require-object-in-propequal.md) | enforce use of objects as expected value in `assert.propEqual` | ✅ |  |  |
+| [resolve-async](./docs/rules/resolve-async.md) | require that async calls are resolved | ✅ |  |  |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rules/assert-args.md
+++ b/docs/rules/assert-args.md
@@ -1,6 +1,6 @@
 # Enforce that the correct number of assert arguments are used (assert-args)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit's assertions expect a certain number of arguments based on what sort of
 condition is being evaluated.

--- a/docs/rules/literal-compare-order.md
+++ b/docs/rules/literal-compare-order.md
@@ -1,8 +1,8 @@
 # Enforce comparison assertions have arguments in the right order (literal-compare-order)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 QUnit's many comparison assertions (`equal`, `strictEqual`, etc.) distinguish
 between an expected value and an actual value, and report incorrect assertions

--- a/docs/rules/no-arrow-tests.md
+++ b/docs/rules/no-arrow-tests.md
@@ -1,8 +1,8 @@
 # Disallow arrow functions as QUnit test/module callbacks (no-arrow-tests)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 QUnit test and module callbacks can share state by modifying properties of
 `this` within those callbacks.

--- a/docs/rules/no-assert-equal-boolean.md
+++ b/docs/rules/no-assert-equal-boolean.md
@@ -1,8 +1,8 @@
 # Require use of boolean assertions (no-assert-equal-boolean)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 The boolean assertion functions `assert.true()` and `assert.false()` are available as of QUnit 2.11. These assertions can be stricter and clearer about intent when compared to using other assertion functions for boolean comparisons.
 

--- a/docs/rules/no-assert-logical-expression.md
+++ b/docs/rules/no-assert-logical-expression.md
@@ -1,6 +1,6 @@
 # Disallow binary logical expressions in assert arguments (no-assert-logical-expression)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Generally, it is not a good idea to use logical expressions as assertion arguments. Logical-and assertions can be broken down into multiple assertions, while logical-or assertions may be indicative of uncertainty or nondeterminism in a test.
 

--- a/docs/rules/no-async-in-loops.md
+++ b/docs/rules/no-async-in-loops.md
@@ -1,6 +1,6 @@
 # Disallow async calls in loops (no-async-in-loops)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Asynchronous operations are much harder to reason about in loops. To increase
 maintainability, asynchronous operations should not be placed within loops.

--- a/docs/rules/no-async-module-callbacks.md
+++ b/docs/rules/no-async-module-callbacks.md
@@ -1,6 +1,6 @@
 # Disallow async module callbacks (no-async-module-callbacks)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit does not support async module callbacks. Only test and hook callbacks
 will work as expected when using `async` and `await`. Code after an `await`

--- a/docs/rules/no-async-test.md
+++ b/docs/rules/no-async-test.md
@@ -1,6 +1,6 @@
 # Disallow the use of asyncTest or QUnit.asyncTest (no-async-test)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating `QUnit.asyncTest()` in favor of `assert.async()` within tests. This rule will flag `asyncTest` and `QUnit.asyncTest` calls and recommend that you use `assert.async()` instead.
 

--- a/docs/rules/no-commented-tests.md
+++ b/docs/rules/no-commented-tests.md
@@ -1,6 +1,6 @@
 # Disallow commented tests (no-commented-tests)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 When developing non-trivial projects, it is unfortunately realistic that unit
 tests may need to be temporarily prevented from running until an upstream

--- a/docs/rules/no-compare-relation-boolean.md
+++ b/docs/rules/no-compare-relation-boolean.md
@@ -1,8 +1,8 @@
 # Disallow comparing relational expressions to booleans in assertions (no-compare-relation-boolean)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Sometimes, QUnit assertions contain relations (such as `expected === actual`). Many of these relations can be expressed better using different assertion methods (such as `assert.strictEqual`). However, even for those comparisons which cannot easily be expressed (such as `actual > expected`), comparing those results explicitly to `true` or `false` provides no added value, because the assertion will show that true equals or does not equal true.
 

--- a/docs/rules/no-conditional-assertions.md
+++ b/docs/rules/no-conditional-assertions.md
@@ -1,6 +1,6 @@
 # Disallow assertions within if statements or conditional expressions (no-conditional-assertions)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 This rule aims to detect non-deterministic unit testing by looking for assertions in an if statement or conditional expression.
 

--- a/docs/rules/no-early-return.md
+++ b/docs/rules/no-early-return.md
@@ -1,6 +1,6 @@
 # Disallow early return in tests (no-early-return)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 This rule aims to prevent early returns in a QUnit test. Unit tests which can return early are usually indications that a test is nondeterministic or too dependent on environmental factors. On the rare occasion that a test should be run conditionally, the whole test should be run or skipped, rather than having a test that can return early (which is harder to maintain).
 

--- a/docs/rules/no-global-assertions.md
+++ b/docs/rules/no-global-assertions.md
@@ -1,6 +1,6 @@
 # Disallow global QUnit assertions (no-global-assertions)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing global QUnit assertions such as `ok()`, requiring consumers to instead use scoped assertions provided on the test callback argument.
 

--- a/docs/rules/no-global-expect.md
+++ b/docs/rules/no-global-expect.md
@@ -1,6 +1,6 @@
 # Disallow global expect (no-global-expect)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing the global `expect` function. This rule will warn when the global `expect` function is used.
 

--- a/docs/rules/no-global-module-test.md
+++ b/docs/rules/no-global-module-test.md
@@ -1,6 +1,6 @@
 # Disallow global module/test/asyncTest (no-global-module-test)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing global functions related to declaring tests and modules. This rule will warn when the global functions are used.
 

--- a/docs/rules/no-global-stop-start.md
+++ b/docs/rules/no-global-stop-start.md
@@ -1,6 +1,6 @@
 # Disallow global stop/start (no-global-stop-start)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating and removing all of its global exports, including
 `stop()` and `start()`.

--- a/docs/rules/no-hooks-from-ancestor-modules.md
+++ b/docs/rules/no-hooks-from-ancestor-modules.md
@@ -1,6 +1,6 @@
 # Disallow the use of hooks from ancestor modules (no-hooks-from-ancestor-modules)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 When a QUnit `module` is used with a nested callback, the callback provides a `hooks`
 object as its first argument. This allows calling `hooks.beforeEach` and `hooks.afterEach`

--- a/docs/rules/no-identical-names.md
+++ b/docs/rules/no-identical-names.md
@@ -1,6 +1,6 @@
 # Disallow identical test and module names (no-identical-names)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Having identical names for two different tests or modules may create
 confusion. For example, when a test with the same name as another test

--- a/docs/rules/no-init.md
+++ b/docs/rules/no-init.md
@@ -1,6 +1,6 @@
 # Disallow use of QUnit.init (no-init)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Early versions of QUnit exposed the `QUnit.init()` function, which allowed
 consumers to reinitialize the QUnit test runner. This has been discouraged for

--- a/docs/rules/no-jsdump.md
+++ b/docs/rules/no-jsdump.md
@@ -1,6 +1,6 @@
 # Disallow use of QUnit.jsDump (no-jsdump)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 When QUnit was first developed, it used the `jsDump` library for serializing
 objects as strings. Since then, QUnit has forked and evolved the library. To

--- a/docs/rules/no-negated-ok.md
+++ b/docs/rules/no-negated-ok.md
@@ -1,8 +1,8 @@
 # Disallow negation in assert.ok/assert.notOk (no-negated-ok)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Negated `assert.ok()` or `assert.notOk()` solutions can be misleading, because
 the error message may show a double negative or otherwise be hard to read. It

--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -1,6 +1,6 @@
 # Disallow nested QUnit.test() calls (no-nested-tests)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 This rule prevents from incorrect usage of [Nested Scope](https://github.com/qunitjs/qunit/blob/master/docs/QUnit/module.md#nested-scope). Developer can write nested test instead of nested module by mistake. In this case test will still be executed, but effects may be unexpected.
 

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -1,8 +1,8 @@
 # Disallow equality comparisons in assert.ok/assert.notOk (no-ok-equality)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Equality comparisons in `assert.ok` or `assert.notOk` calls are not valuable
 because if the assertion fails, QUnit cannot reveal any comparison information.

--- a/docs/rules/no-only.md
+++ b/docs/rules/no-only.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.only (no-only)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 `QUnit.only` is useful for restricting a test run to just one test while developing, but committing a test file using this function to a repository is dangerous because it will ensure that the rest of the test suite is not run.
 

--- a/docs/rules/no-qunit-push.md
+++ b/docs/rules/no-qunit-push.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.push (no-qunit-push)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 When writing custom assertions, the proper way to log an assertion result
 used to be calling `QUnit.push()` with the assertion result data. However, in

--- a/docs/rules/no-qunit-start-in-tests.md
+++ b/docs/rules/no-qunit-start-in-tests.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.start() within tests or test hooks (no-qunit-start-in-tests)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 The purpose of this rule is to ensure that `QUnit.start()` is not used within tests or test hooks.
 

--- a/docs/rules/no-qunit-stop.md
+++ b/docs/rules/no-qunit-stop.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.stop (no-qunit-stop)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit's handling of asynchronous tests used to be via tracking a global
 semaphore and not starting a test until the previous test had decremented the

--- a/docs/rules/no-reassign-log-callbacks.md
+++ b/docs/rules/no-reassign-log-callbacks.md
@@ -1,6 +1,6 @@
 # Disallow overwriting of QUnit logging callbacks (no-reassign-log-callbacks)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 In early versions of QUnit, it was possible to create logging functions that
 would be invoked as QUnit processed tests and modules by assigning to specific

--- a/docs/rules/no-reset.md
+++ b/docs/rules/no-reset.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.reset (no-reset)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Early versions of QUnit exposed the `QUnit.reset()` function, which allowed
 consumers to invoke the internal QUnit fixture reset logic. This has been

--- a/docs/rules/no-setup-teardown.md
+++ b/docs/rules/no-setup-teardown.md
@@ -1,8 +1,8 @@
 # Disallow setup/teardown module hooks (no-setup-teardown)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
-:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 QUnit supports two hooks at the module level: `beforeEach` and `afterEach`.
 These hooks are run before and after each test, respectively. Before QUnit

--- a/docs/rules/no-test-expect-argument.md
+++ b/docs/rules/no-test-expect-argument.md
@@ -1,6 +1,6 @@
 # Disallow the expect argument in QUnit.test (no-test-expect-argument)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 is deprecating expect counts as the second argument of `QUnit.test`. Users are expected to use `assert.expect()` instead.
 

--- a/docs/rules/no-throws-string.md
+++ b/docs/rules/no-throws-string.md
@@ -1,6 +1,6 @@
 # Disallow assert.throws() with block, string, and message args (no-throws-string)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit 2.0 has deprecated the `assert.throws(block, string, message)` form of
 `assert.throws()`. This rule can be used to flag uses of the deprecated form

--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -1,6 +1,6 @@
 # Enforce that `expect` is called (require-expect)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 QUnit's `assert.expect(...)` helps developers create tests that correctly fail
 when their expected number of assertions are not called. QUnit will throw an

--- a/docs/rules/require-object-in-propequal.md
+++ b/docs/rules/require-object-in-propequal.md
@@ -1,6 +1,6 @@
 # Enforce use of objects as expected value in `assert.propEqual` (require-object-in-propequal)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 The `assert.propEqual` assertion is for the strict-equality comparison of own-properties
 of two objects. If the expected value is a string or other non-object, the assertion

--- a/docs/rules/resolve-async.md
+++ b/docs/rules/resolve-async.md
@@ -1,6 +1,6 @@
 # Require that async calls are resolved (resolve-async)
 
-:white_check_mark: The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
+✅ The `"extends": "plugin:qunit/recommended"` property in a configuration file enables this rule.
 
 Asynchronous operations on QUnit tests should be resolved within the scope of
 the test to maximize readability and maintainability. Also, if there are more

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -9,8 +9,8 @@ const readmeContent = fs.readFileSync(pathReadme, "utf8");
 const tablePlaceholder = /<!--RULES_TABLE_START-->[\S\s]*<!--RULES_TABLE_END-->/;
 
 // Config/preset/fixable emojis.
-const EMOJI_RECOMMENDED = ":white_check_mark:";
-const EMOJI_FIXABLE = ":wrench:";
+const EMOJI_RECOMMENDED = "✅";
+const EMOJI_FIXABLE = "🔧";
 const EMOJI_SUGGESTIONS = "💡";
 
 // Generate rule table contents.

--- a/tests/index.js
+++ b/tests/index.js
@@ -18,8 +18,8 @@ const assert = require("chai").assert,
 //------------------------------------------------------------------------------
 
 const MESSAGES = {
-    fixable: ":wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.",
-    configRecommended: ":white_check_mark: The `\"extends\": \"plugin:qunit/recommended\"` property in a configuration file enables this rule.",
+    fixable: "🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.",
+    configRecommended: "✅ The `\"extends\": \"plugin:qunit/recommended\"` property in a configuration file enables this rule.",
     hasSuggestions: "💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)."
 };
 


### PR DESCRIPTION
Just use the standard ones for the fixable/recommended emojis.

Code editors like VSCode can't render `:white_check_mark:` but they can render standard emojis like ✅. Standard emojis are more universal and don't require special rendering engines. Easier to work with and preview locally.