### PR TITLE
Update: Mark no-assert-equal and no-assert-ok as deprecated

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -169,7 +169,8 @@
 
         // eslint-plugin-eslint-plugin
         "eslint-plugin/meta-property-ordering": ["error", [
-            "type", "docs", "fixable", "messages", "schema", "deprecated", "replacedBy"
+            "type", "docs", "fixable", "hasSuggestions", "messages", "schema",
+            "deprecated", "replacedBy"
         ]],
         "eslint-plugin/require-meta-docs-url": ["error", {
             "pattern": "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/{{name}}.md"

--- a/README.md
+++ b/README.md
@@ -33,10 +33,8 @@ Each rule has emojis denoting:
 | [assert-args](./docs/rules/assert-args.md) | enforce that the correct number of assert arguments are used | ✅ |  |  |
 | [literal-compare-order](./docs/rules/literal-compare-order.md) | enforce comparison assertions have arguments in the right order | ✅ | 🔧 |  |
 | [no-arrow-tests](./docs/rules/no-arrow-tests.md) | disallow arrow functions as QUnit test/module callbacks | ✅ | 🔧 |  |
-| [no-assert-equal](./docs/rules/no-assert-equal.md) | disallow the use of assert.equal |  |  | 💡 |
 | [no-assert-equal-boolean](./docs/rules/no-assert-equal-boolean.md) | require use of boolean assertions | ✅ | 🔧 |  |
 | [no-assert-logical-expression](./docs/rules/no-assert-logical-expression.md) | disallow binary logical expressions in assert arguments | ✅ |  |  |
-| [no-assert-ok](./docs/rules/no-assert-ok.md) | disallow the use of assert.ok/assert.notOk |  |  |  |
 | [no-async-in-loops](./docs/rules/no-async-in-loops.md) | disallow async calls in loops | ✅ |  |  |
 | [no-async-module-callbacks](./docs/rules/no-async-module-callbacks.md) | disallow async module callbacks | ✅ |  |  |
 | [no-async-test](./docs/rules/no-async-test.md) | disallow the use of asyncTest or QUnit.asyncTest | ✅ |  |  |
@@ -71,6 +69,19 @@ Each rule has emojis denoting:
 | [resolve-async](./docs/rules/resolve-async.md) | require that async calls are resolved | ✅ |  |  |
 
 <!--RULES_TABLE_END-->
+
+### Deprecated Rules
+
+The following rules are deprecated:
+
+<!--DEPRECATED_RULES_TABLE_START-->
+
+| Name | Replaced By |
+|:-----|:------------|
+| [no-assert-equal](./docs/rules/no-assert-equal.md) | [no-loose-assertions](./docs/rules/no-loose-assertions.md)
+| [no-assert-ok](./docs/rules/no-assert-ok.md) | [no-loose-assertions](./docs/rules/no-loose-assertions.md)
+
+<!--DEPRECATED_RULES_TABLE_END-->
 
 ## Contributors
 

--- a/docs/rules/no-assert-equal.md
+++ b/docs/rules/no-assert-equal.md
@@ -1,5 +1,7 @@
 # Disallow the use of assert.equal (no-assert-equal)
 
+**This rule has been deprecated.** Please see the project README for information about replacement rules.
+
 💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 The `assert.equal` assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.

--- a/docs/rules/no-assert-ok.md
+++ b/docs/rules/no-assert-ok.md
@@ -1,5 +1,7 @@
 # Disallow the use of assert.ok/assert.notOk (no-assert-ok)
 
+**This rule has been deprecated.** Please see the project README for information about replacement rules.
+
 `assert.ok` and `assert.notOk` pass for any truthy/falsy argument. As [many expressions evaluate to true/false in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) the usage of `assert.ok` is potentially error prone. In general, it should be advisable to always test for exact values in tests which makes tests a lot more solid.
 
 An example when using `assert.ok` can involuntarily go wrong:

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -24,6 +24,7 @@ module.exports = {
             category: "Best Practices",
             url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md"
         },
+        hasSuggestions: true,
         messages: {
             unexpectedGlobalEqual: "Unexpected equal. Use strictEqual, deepEqual, or propEqual.",
             unexpectedAssertEqual: "Unexpected {{assertVar}}.equal. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual.",
@@ -32,7 +33,8 @@ module.exports = {
             switchToStrictEqual: "Switch to strictEqual."
         },
         schema: [],
-        hasSuggestions: true
+        deprecated: true,
+        replacedBy: ["qunit/no-loose-assertions"]
     },
 
     create: function (context) {

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -35,7 +35,9 @@ module.exports = {
             [GLOBAL_ERROR_MESSAGE_ID]: "Unexpected {{assertion}}. Use strictEqual, deepEqual, or propEqual.",
             [LOCAL_ERROR_MESSAGE_ID]: "Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.strictEqual, {{assertVar}}.deepEqual, or {{assertVar}}.propEqual."
         },
-        schema: []
+        schema: [],
+        deprecated: true,
+        replacedBy: ["qunit/no-loose-assertions"]
     },
 
     create: utils.createAssertionCheck(assertions, ERROR_MESSAGE_CONFIG)

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -6,7 +6,8 @@ const { rules, configs } = require("../");
 
 const pathReadme = path.resolve(__dirname, "../README.md");
 const readmeContent = fs.readFileSync(pathReadme, "utf8");
-const tablePlaceholder = /<!--RULES_TABLE_START-->[\S\s]*<!--RULES_TABLE_END-->/;
+const rulesTablePlaceholder = /<!--RULES_TABLE_START-->[\S\s]*<!--RULES_TABLE_END-->/;
+const deprecatedRulesTablePlaceholder = /<!--DEPRECATED_RULES_TABLE_START-->[\S\s]*<!--DEPRECATED_RULES_TABLE_END-->/;
 
 // Config/preset/fixable emojis.
 const EMOJI_RECOMMENDED = "✅";
@@ -15,6 +16,7 @@ const EMOJI_SUGGESTIONS = "💡";
 
 // Generate rule table contents.
 const rulesTableContent = Object.keys(rules)
+    .filter(ruleName => !rules[ruleName].meta.deprecated)
     .sort()
     .map((ruleName) => {
         // Check which emojis to show for this rule.
@@ -28,10 +30,37 @@ const rulesTableContent = Object.keys(rules)
     })
     .join("\n");
 
+// Generate deprecated rule table contents.
+const deprecatedRulesTableContent = Object.keys(rules)
+    .filter(ruleName => rules[ruleName].meta.deprecated)
+    .sort()
+    .map((ruleName) => {
+        const url = `./docs/rules/${ruleName}.md`;
+        const link = `[${ruleName}](${url})`;
+
+        const replacedBy = rules[ruleName].meta.replacedBy || [];
+
+        const replacedByLinks = replacedBy
+            .map(replacementName => {
+                const simpleName = replacementName.replace(/^qunit\//, "");
+
+                const replaceUrl = `./docs/rules/${simpleName}.md`;
+                return `[${simpleName}](${replaceUrl})`;
+            });
+
+        return `| ${link} | ${replacedByLinks.join(", ")}`;
+    })
+    .join("\n");
+
 fs.writeFileSync(
     pathReadme,
-    readmeContent.replace(
-        tablePlaceholder,
-        `<!--RULES_TABLE_START-->\n\n| Name | Description | ${EMOJI_RECOMMENDED} | ${EMOJI_FIXABLE} | ${EMOJI_SUGGESTIONS} |\n|:--------|:--------|:---|:---|:---|\n${rulesTableContent}\n\n<!--RULES_TABLE_END-->`
-    )
+    readmeContent
+        .replace(
+            rulesTablePlaceholder,
+            `<!--RULES_TABLE_START-->\n\n| Name | Description | ${EMOJI_RECOMMENDED} | ${EMOJI_FIXABLE} | ${EMOJI_SUGGESTIONS} |\n|:--------|:--------|:---|:---|:---|\n${rulesTableContent}\n\n<!--RULES_TABLE_END-->`
+        )
+        .replace(
+            deprecatedRulesTablePlaceholder,
+            `<!--DEPRECATED_RULES_TABLE_START-->\n\n| Name | Replaced By |\n|:-----|:------------|\n${deprecatedRulesTableContent}\n\n<!--DEPRECATED_RULES_TABLE_END-->`
+        )
 );

--- a/tests/index.js
+++ b/tests/index.js
@@ -18,6 +18,7 @@ const assert = require("chai").assert,
 //------------------------------------------------------------------------------
 
 const MESSAGES = {
+    deprecated: "**This rule has been deprecated.** Please see the project README for information about replacement rules.",
     fixable: "🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.",
     configRecommended: "✅ The `\"extends\": \"plugin:qunit/recommended\"` property in a configuration file enables this rule.",
     hasSuggestions: "💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)."
@@ -73,16 +74,25 @@ describe("index.js", function () {
                     // Decide which notices should be shown at the top of the doc.
                     const expectedNotices = [];
                     const unexpectedNotices = [];
+
+                    if (rules[ruleName].meta.deprecated) {
+                        expectedNotices.push("deprecated");
+                    } else {
+                        unexpectedNotices.push("deprecated");
+                    }
+
                     if (configs.recommended.rules[`qunit/${ruleName}`]) {
                         expectedNotices.push("configRecommended");
                     } else {
                         unexpectedNotices.push("configRecommended");
                     }
+
                     if (rules[ruleName].meta.fixable) {
                         expectedNotices.push("fixable");
                     } else {
                         unexpectedNotices.push("fixable");
                     }
+
                     if (rules[ruleName].meta.hasSuggestions) {
                         expectedNotices.push("hasSuggestions");
                     } else {


### PR DESCRIPTION
Replaced by `no-loose-assertions`, which covers these rules but is also more flexible.