### PR TITLE
Ensure rule docs mention all rule options

### DIFF
--- a/docs/rules/no-loose-assertions.md
+++ b/docs/rules/no-loose-assertions.md
@@ -14,15 +14,6 @@ test('test myFunc returns a truthy value', (assert) => {
 
 Here by mistake a developer just passed to `assert.ok` a pointer to `myFunc` instead of explicitly calling it. This test is going pass no matter how `myFunc` changes. Using `assert.strictEqual(myFunc, theReturnValue)` solves the problem as this becomes an explicit check for equality.
 
-The assertions to lint against can be controlled with an array of assertions (default `["equal", "notEqual", "ok", "notOk"]`).
-
-To fine tune the error message (which by default will recommend to use `strictEqual`, `notStrictEqual`, `deepEqual`, or `propEqual`) a configuration object can be passed as an option instead of a string. The configuration object has two properties:
-
-* `disallowed`: the name of the assertion to disallow (either `equal`, `ok`, or `notOk`);
-* `recommended`: an array of strings representing the recommended options to display as an error message. The strings in the array will be concatenated to build the error message: `Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.<recommended_1>, {{assertVar}}.<recommended_2>.` when using local assertions and `Unexpected {{assertion}}. Use <recommended_1>, <recommended_2>.` when using global assertions.
-
-If an assertion is passed twice as a string and object the first configuration will be used and any other configuration will be ignored.
-
 ## Rule Details
 
 The following patterns are considered warnings:
@@ -87,6 +78,17 @@ QUnit.test('Name', function () { propEqual(a, b); });
 QUnit.test('Name', function (assert) { assert.notEqual(a, b); });
 
 ```
+
+## Options
+
+The assertions to lint against can be controlled with an array of assertions (default `["equal", "notEqual", "ok", "notOk"]`).
+
+To fine tune the error message (which by default will recommend to use `strictEqual`, `notStrictEqual`, `deepEqual`, or `propEqual`) a configuration object can be passed as an option instead of a string. The configuration object has two properties:
+
+* `disallowed`: the name of the assertion to disallow (either `equal`, `ok`, or `notOk`);
+* `recommended`: an array of strings representing the recommended options to display as an error message. The strings in the array will be concatenated to build the error message: `Unexpected {{assertVar}}.{{assertion}}. Use {{assertVar}}.<recommended_1>, {{assertVar}}.<recommended_2>.` when using local assertions and `Unexpected {{assertion}}. Use <recommended_1>, <recommended_2>.` when using global assertions.
+
+If an assertion is passed twice as a string and object the first configuration will be used and any other configuration will be ignored.
 
 ## Further Reading
 

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -62,7 +62,7 @@ QUnit.test("Name", function (assert) { assert.ok(x instanceof Number); });
 
 ```
 
-## Configuration
+## Options
 
 This rule takes an optional object containing:
 


### PR DESCRIPTION
Add test to ensure:

1. Any rule with options has a `## Options` section in its rule doc.
2. Any named rule options are mentioned in the rule doc.

Based on the same test I wrote here: https://github.com/ember-cli/eslint-plugin-ember/blob/4f26c0bc7e34400007e02939a9c6e183078a3e87/tests/rule-setup.js#L111
