### PR TITLE
Fix: Check for arrow functions in utils.getAssertContextNameForTest

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,7 +218,7 @@ exports.isSkip = function (calleeNode) {
 
 exports.getAssertContextNameForTest = function (argumentsNodes) {
     const functionExpr = argumentsNodes.find(function (argNode) {
-        return argNode.type === "FunctionExpression";
+        return argNode.type === "FunctionExpression" || argNode.type === "ArrowFunctionExpression";
     });
 
     return this.getAssertContextName(functionExpr);

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -19,6 +19,10 @@ function wrap(assertionCode, testName = "Name") {
     return `QUnit.test('${testName}', function (assert) { ${assertionCode} });`;
 }
 
+function wrapArrow(assertionCode, testName = "Name") {
+    return `QUnit.test('${testName}', (assert) => { ${assertionCode} });`;
+}
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -369,6 +373,17 @@ ruleTester.run("assert-args", rule, {
         },
         {
             code: wrap("assert.strictEqual();"),
+            errors: [{
+                messageId: "unexpectedArgCountNoMessage",
+                data: {
+                    callee: "assert.strictEqual",
+                    argCount: 0
+                }
+            }]
+        },
+        {
+            code: wrapArrow("assert.strictEqual();"),
+            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "unexpectedArgCountNoMessage",
                 data: {

--- a/tests/lib/rules/literal-compare-order.js
+++ b/tests/lib/rules/literal-compare-order.js
@@ -19,6 +19,10 @@ function wrap(assertionCode, testName = "Name") {
     return `QUnit.test('${testName}', function (assert) { ${assertionCode} });`;
 }
 
+function wrapArrow(assertionCode, testName = "Name") {
+    return `QUnit.test('${testName}', (assert) => { ${assertionCode} });`;
+}
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -107,6 +111,18 @@ ruleTester.run("literal-compare-order", rule, {
         {
             code: wrap("assert.equal('Literal', variable);"),
             output: wrap("assert.equal(variable, 'Literal');"),
+            errors: [{
+                messageId: "actualFirst",
+                data: {
+                    expected: "'Literal'",
+                    actual: "variable"
+                }
+            }]
+        },
+        {
+            code: wrapArrow("assert.equal('Literal', variable);"),
+            output: wrapArrow("assert.equal(variable, 'Literal');"),
+            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "actualFirst",
                 data: {

--- a/tests/lib/rules/no-assert-equal-boolean.js
+++ b/tests/lib/rules/no-assert-equal-boolean.js
@@ -63,6 +63,12 @@ ruleTester.run("no-assert-equal-boolean", rule, {
             errors: [{ messageId: "useAssertTrueOrFalse" }]
         },
         {
+            code: "QUnit.test('Name', (assert) => { assert.equal(a, true); });",
+            output: "QUnit.test('Name', (assert) => { assert.true(a); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+        {
             code: "QUnit.test('Name', function (assert) { assert.equal(a, false); });",
             output: "QUnit.test('Name', function (assert) { assert.false(a); });",
             errors: [{ messageId: "useAssertTrueOrFalse" }]

--- a/tests/lib/rules/no-assert-equal.js
+++ b/tests/lib/rules/no-assert-equal.js
@@ -65,6 +65,28 @@ ruleTester.run("no-assert-equal", rule, {
             }]
         },
         {
+            code: "QUnit.test('Name', (assert) => { assert.equal(a, b); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpectedAssertEqual",
+                data: { assertVar: "assert" },
+                suggestions: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        output: "QUnit.test('Name', (assert) => { assert.deepEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        output: "QUnit.test('Name', (assert) => { assert.propEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        output: "QUnit.test('Name', (assert) => { assert.strictEqual(a, b); });"
+                    }
+                ]
+            }]
+        },
+        {
             code: "QUnit.test('Name', function (foo) { foo.equal(a, b); });",
             errors: [{
                 messageId: "unexpectedAssertEqual",

--- a/tests/lib/rules/no-assert-logical-expression.js
+++ b/tests/lib/rules/no-assert-logical-expression.js
@@ -19,6 +19,10 @@ function wrap(code) {
     return `QUnit.test('test', function (assert) { ${code} });`;
 }
 
+function wrapArrow(code) {
+    return `QUnit.test('test', (assert) => { ${code} });`;
+}
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -66,6 +70,19 @@ ruleTester.run("no-assert-logical-expression", rule, {
                 type: "LogicalExpression",
                 line: 1,
                 column: 50
+            }]
+        },
+        {
+            code: wrapArrow("assert.ok(foo && bar);"),
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "noLogicalOperator",
+                data: {
+                    operator: "&&"
+                },
+                type: "LogicalExpression",
+                line: 1,
+                column: 44
             }]
         },
         {

--- a/tests/lib/rules/no-assert-ok.js
+++ b/tests/lib/rules/no-assert-ok.js
@@ -48,6 +48,17 @@ ruleTester.run("no-assert-ok", rule, {
             }]
         },
         {
+            code: "QUnit.test('Name', (assert) => { assert.ok(a); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpectedLocalOkNotOk",
+                data: {
+                    assertVar: "assert",
+                    assertion: "ok"
+                }
+            }]
+        },
+        {
             code: "QUnit.test('Name', function (foo) { foo.ok(a); });",
             errors: [{
                 messageId: "unexpectedLocalOkNotOk",

--- a/tests/lib/rules/no-async-in-loops.js
+++ b/tests/lib/rules/no-async-in-loops.js
@@ -499,6 +499,18 @@ ruleTester.run("no-async-in-loops", rule, {
             }]
         },
         {
+            code: "test('name', (assert) => { while (false) assert.async(); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpectedAsyncInLoop",
+                data: {
+                    call: "assert.async()",
+                    loopTypeText: "while loop"
+                },
+                type: "CallExpression"
+            }]
+        },
+        {
             code: "test('name', function (assert) { while (false) { assert.async(); } });",
             errors: [{
                 messageId: "unexpectedAsyncInLoop",

--- a/tests/lib/rules/no-compare-relation-boolean.js
+++ b/tests/lib/rules/no-compare-relation-boolean.js
@@ -15,28 +15,21 @@ const rule = require("../../../lib/rules/no-compare-relation-boolean"),
 // Helper Functions
 //------------------------------------------------------------------------------
 
-function wrapInQUnitTest(code) {
+function wrap(code) {
     return `QUnit.test('test', function (assert) { ${code} });`;
 }
 
-function generateInvalidCase({ code, output, options }) {
-    const testCase = {
-        code: wrapInQUnitTest(code),
+function wrapArrow(code) {
+    return `QUnit.test('test', (assert) => { ${code} });`;
+}
+
+function addErrors(testCase) {
+    return Object.assign({
         errors: [{
             messageId: "redundantComparison",
             type: "CallExpression"
         }]
-    };
-
-    if (output) {
-        testCase.output = wrapInQUnitTest(output);
-    }
-
-    if (options) {
-        testCase.options = options;
-    }
-
-    return testCase;
+    }, testCase);
 }
 
 //------------------------------------------------------------------------------
@@ -60,170 +53,175 @@ ruleTester.run("no-compare-relation-boolean", rule, {
         // Comparing against something that isn't a boolean literal is fine
         "assert.equal(a > b, 1);",
         "assert.equal(a > b, c);"
-    ].map(code => wrapInQUnitTest(code)),
+    ].map(code => wrap(code)),
 
     invalid: [
         {
-            code: "assert.equal(a === b, true);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.equal(a === b, true);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.equal(a === b, false);",
-            output: "assert.notOk(a === b);"
-        },
-
-        {
-            code: "assert.equal(a === b, true, 'message');", // With message
-            output: "assert.ok(a === b, 'message');"
+            code: wrapArrow("assert.equal(a === b, true);"),
+            output: wrapArrow("assert.ok(a === b);"),
+            parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "assert.equal(a === b, false, 'message');", // With message
-            output: "assert.notOk(a === b, 'message');"
+            code: wrap("assert.equal(a === b, false);"),
+            output: wrap("assert.notOk(a === b);")
         },
 
         {
-            code: "assert.strictEqual(a === b, true);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.equal(a === b, true, 'message');"), // With message
+            output: wrap("assert.ok(a === b, 'message');")
         },
         {
-            code: "assert.strictEqual(a === b, false);",
-            output: "assert.notOk(a === b);"
-        },
-
-        {
-            code: "assert.deepEqual(a === b, true);",
-            output: "assert.ok(a === b);"
-        },
-        {
-            code: "assert.deepEqual(a === b, false);",
-            output: "assert.notOk(a === b);"
+            code: wrap("assert.equal(a === b, false, 'message');"), // With message
+            output: wrap("assert.notOk(a === b, 'message');")
         },
 
         {
-            code: "assert.propEqual(a === b, true);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.strictEqual(a === b, true);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.propEqual(a === b, false);",
-            output: "assert.notOk(a === b);"
-        },
-
-        {
-            code: "assert.notEqual(a === b, true);",
-            output: "assert.notOk(a === b);"
-        },
-        {
-            code: "assert.notEqual(a === b, false);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.strictEqual(a === b, false);"),
+            output: wrap("assert.notOk(a === b);")
         },
 
         {
-            code: "assert.notStrictEqual(a === b, true);",
-            output: "assert.notOk(a === b);"
+            code: wrap("assert.deepEqual(a === b, true);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.notStrictEqual(a === b, false);",
-            output: "assert.ok(a === b);"
-        },
-
-        {
-            code: "assert.notDeepEqual(a === b, true);",
-            output: "assert.notOk(a === b);"
-        },
-        {
-            code: "assert.notDeepEqual(a === b, false);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.deepEqual(a === b, false);"),
+            output: wrap("assert.notOk(a === b);")
         },
 
         {
-            code: "assert.notPropEqual(a === b, true);",
-            output: "assert.notOk(a === b);"
+            code: wrap("assert.propEqual(a === b, true);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.notPropEqual(a === b, false);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.propEqual(a === b, false);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+
+        {
+            code: wrap("assert.notEqual(a === b, true);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notEqual(a === b, false);"),
+            output: wrap("assert.ok(a === b);")
+        },
+
+        {
+            code: wrap("assert.notStrictEqual(a === b, true);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notStrictEqual(a === b, false);"),
+            output: wrap("assert.ok(a === b);")
+        },
+
+        {
+            code: wrap("assert.notDeepEqual(a === b, true);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notDeepEqual(a === b, false);"),
+            output: wrap("assert.ok(a === b);")
+        },
+
+        {
+            code: wrap("assert.notPropEqual(a === b, true);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notPropEqual(a === b, false);"),
+            output: wrap("assert.ok(a === b);")
         },
 
         // Argument order does not matter for this rule
         {
-            code: "assert.equal(true, a === b);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.equal(true, a === b);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.equal(false, a === b);",
-            output: "assert.notOk(a === b);"
-        },
-
-        {
-            code: "assert.equal(true, a === b, 'message');", // With message
-            output: "assert.ok(a === b, 'message');"
-        },
-        {
-            code: "assert.equal(false, a === b, 'message');", // With message
-            output: "assert.notOk(a === b, 'message');"
+            code: wrap("assert.equal(false, a === b);"),
+            output: wrap("assert.notOk(a === b);")
         },
 
         {
-            code: "assert.strictEqual(true, a === b);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.equal(true, a === b, 'message');"), // With message
+            output: wrap("assert.ok(a === b, 'message');")
         },
         {
-            code: "assert.strictEqual(false, a === b);",
-            output: "assert.notOk(a === b);"
-        },
-
-        {
-            code: "assert.deepEqual(true, a === b);",
-            output: "assert.ok(a === b);"
-        },
-        {
-            code: "assert.deepEqual(false, a === b);",
-            output: "assert.notOk(a === b);"
+            code: wrap("assert.equal(false, a === b, 'message');"), // With message
+            output: wrap("assert.notOk(a === b, 'message');")
         },
 
         {
-            code: "assert.propEqual(true, a === b);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.strictEqual(true, a === b);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.propEqual(false, a === b);",
-            output: "assert.notOk(a === b);"
-        },
-
-        {
-            code: "assert.notEqual(true, a === b);",
-            output: "assert.notOk(a === b);"
-        },
-        {
-            code: "assert.notEqual(false, a === b);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.strictEqual(false, a === b);"),
+            output: wrap("assert.notOk(a === b);")
         },
 
         {
-            code: "assert.notStrictEqual(true, a === b);",
-            output: "assert.notOk(a === b);"
+            code: wrap("assert.deepEqual(true, a === b);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.notStrictEqual(false, a === b);",
-            output: "assert.ok(a === b);"
-        },
-
-        {
-            code: "assert.notDeepEqual(true, a === b);",
-            output: "assert.notOk(a === b);"
-        },
-        {
-            code: "assert.notDeepEqual(false, a === b);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.deepEqual(false, a === b);"),
+            output: wrap("assert.notOk(a === b);")
         },
 
         {
-            code: "assert.notPropEqual(true, a === b);",
-            output: "assert.notOk(a === b);"
+            code: wrap("assert.propEqual(true, a === b);"),
+            output: wrap("assert.ok(a === b);")
         },
         {
-            code: "assert.notPropEqual(false, a === b);",
-            output: "assert.ok(a === b);"
+            code: wrap("assert.propEqual(false, a === b);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+
+        {
+            code: wrap("assert.notEqual(true, a === b);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notEqual(false, a === b);"),
+            output: wrap("assert.ok(a === b);")
+        },
+
+        {
+            code: wrap("assert.notStrictEqual(true, a === b);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notStrictEqual(false, a === b);"),
+            output: wrap("assert.ok(a === b);")
+        },
+
+        {
+            code: wrap("assert.notDeepEqual(true, a === b);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notDeepEqual(false, a === b);"),
+            output: wrap("assert.ok(a === b);")
+        },
+
+        {
+            code: wrap("assert.notPropEqual(true, a === b);"),
+            output: wrap("assert.notOk(a === b);")
+        },
+        {
+            code: wrap("assert.notPropEqual(false, a === b);"),
+            output: wrap("assert.ok(a === b);")
         }
-    ].map(code => generateInvalidCase(code))
+    ].map(testCase => addErrors(testCase))
 });

--- a/tests/lib/rules/no-conditional-assertions.js
+++ b/tests/lib/rules/no-conditional-assertions.js
@@ -15,20 +15,17 @@ const rule = require("../../../lib/rules/no-conditional-assertions"),
 // Helpers
 //------------------------------------------------------------------------------
 
-function wrapInQUnitTest(code) {
+function wrap(code) {
     return `QUnit.test('test', function (assert) { ${code} });`;
 }
 
-function wrapInValidTestObject(code) {
-    return {
-        code: wrapInQUnitTest(code),
-        parserOptions: { ecmaVersion: 6 }
-    };
+function wrapArrow(code) {
+    return `QUnit.test('test', (assert) => { ${code} });`;
 }
 
 function wrapInInvalidTestObject(code) {
     return {
-        code: wrapInQUnitTest(code),
+        code: code,
         errors: [{
             messageId: "noAssertionInsideConditional",
             type: "CallExpression"
@@ -40,7 +37,7 @@ function wrapInInvalidTestObject(code) {
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 ruleTester.run("no-conditional-assertions", rule, {
 
     valid: [
@@ -69,19 +66,20 @@ ruleTester.run("no-conditional-assertions", rule, {
             "if (foo) doSomething();",
             "foo ? doSomething() : false;",
             "foo ? false : doSomething();"
-        ].map(code => wrapInValidTestObject(code)),
+        ].map(code => wrap(code)),
 
         // Conditional tests are okay
         "if (foo) QUnit.test('test', function (assert) { assert.ok(true); });"
     ],
 
     invalid: [
-        "if (foo) assert.ok(true);",
-        "if (foo) { assert.ok(true); }",
-        "if (foo) { assert.true(true); }",
-        "if (foo) {} else if (bar) assert.ok(true);",
-        "if (foo) {} else assert.ok(true);",
-        "foo ? assert.ok(true) : false",
-        "foo ? false : assert.ok(true)"
+        wrap("if (foo) assert.ok(true);"),
+        wrapArrow("if (foo) assert.ok(true);"),
+        wrap("if (foo) { assert.ok(true); }"),
+        wrap("if (foo) { assert.true(true); }"),
+        wrap("if (foo) {} else if (bar) assert.ok(true);"),
+        wrap("if (foo) {} else assert.ok(true);"),
+        wrap("foo ? assert.ok(true) : false"),
+        wrap("foo ? false : assert.ok(true)")
     ].map(code => wrapInInvalidTestObject(code))
 });

--- a/tests/lib/rules/no-early-return.js
+++ b/tests/lib/rules/no-early-return.js
@@ -52,6 +52,15 @@ ruleTester.run("no-early-return", rule, {
             }]
         },
 
+        {
+            code: "QUnit.test('a test', (assert) => { if (true) return; assert.ok(true); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "noEarlyReturn",
+                type: "ReturnStatement"
+            }]
+        },
+
         // Return in nested function before assertion is considered early return
         {
             code: "QUnit.test('a test', function (assert) { setTimeout(function () { if (true) return; assert.ok(true); }, 0); });",

--- a/tests/lib/rules/no-loose-assertions.js
+++ b/tests/lib/rules/no-loose-assertions.js
@@ -48,6 +48,17 @@ ruleTester.run("no-loose-assertions", rule, {
             }]
         },
         {
+            code: "QUnit.test('Name', (assert) => { assert.ok(a); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpectedLocalLooseAssertion",
+                data: {
+                    assertVar: "assert",
+                    assertion: "ok"
+                }
+            }]
+        },
+        {
             code: "QUnit.test('Name', function (foo) { foo.ok(a); });",
             errors: [{
                 messageId: "unexpectedLocalLooseAssertion",

--- a/tests/lib/rules/no-negated-ok.js
+++ b/tests/lib/rules/no-negated-ok.js
@@ -19,6 +19,10 @@ function wrap(code) {
     return `QUnit.test('test', function (assert) { ${code} });`;
 }
 
+function wrapArrow(code) {
+    return `QUnit.test('test', (assert) => { ${code} });`;
+}
+
 function createError(callee) {
     return {
         messageId: "noNegationInOk",
@@ -105,6 +109,12 @@ ruleTester.run("no-negated-ok", rule, {
         {
             code: wrap("assert.ok(!foo)"),
             output: wrap("assert.notOk(foo)"),
+            errors: [createError("assert.ok")]
+        },
+        {
+            code: wrapArrow("assert.ok(!foo)"),
+            output: wrapArrow("assert.notOk(foo)"),
+            parserOptions: { ecmaVersion: 6 },
             errors: [createError("assert.ok")]
         },
 

--- a/tests/lib/rules/no-ok-equality.js
+++ b/tests/lib/rules/no-ok-equality.js
@@ -97,6 +97,14 @@ ruleTester.run("no-ok-equality", rule, {
             ]
         },
         {
+            code: "test('Name', (assert) => { assert.ok(x === 1); });",
+            output: "test('Name', (assert) => { assert.strictEqual(x, 1); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                createError("assert.ok", "assert.strictEqual", "x", "1")
+            ]
+        },
+        {
             // With message:
             code: "test('Name', function (assert) { assert.ok(x === 1, 'my message'); });",
             output: "test('Name', function (assert) { assert.strictEqual(x, 1, 'my message'); });",

--- a/tests/lib/rules/no-throws-string.js
+++ b/tests/lib/rules/no-throws-string.js
@@ -54,6 +54,17 @@ ruleTester.run("no-throws-string", rule, {
             }]
         },
         {
+            code: "QUnit.test('a test', (assert) => { assert.throws(function () { }, 'Error message', 'Error should have been thrown'); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "noThrowsWithString",
+                data: {
+                    callee: "assert.throws"
+                },
+                type: "CallExpression"
+            }]
+        },
+        {
             code: "QUnit.test('a test', function (assert) { assert.raises(function () { }, 'Error message', 'Error should have been thrown'); });",
             errors: [{
                 messageId: "noThrowsWithString",

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -143,6 +143,12 @@ ruleTester.run("require-expect", rule, {
             options: ["always"],
             errors: [alwaysErrorMessage("assert.expect")]
         },
+        {
+            code: "test('name', (assert) => { other.assert.expect(0) });",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [alwaysErrorMessage("assert.expect")]
+        },
 
         // assert in loop block
         {

--- a/tests/lib/rules/require-object-in-propequal.js
+++ b/tests/lib/rules/require-object-in-propequal.js
@@ -19,6 +19,10 @@ function wrap(assertionCode, testName = "Name") {
     return `QUnit.test('${testName}', function (assert) { ${assertionCode} });`;
 }
 
+function wrapArrow(assertionCode, testName = "Name") {
+    return `QUnit.test('${testName}', (assert) => { ${assertionCode} });`;
+}
+
 function createInvalid(assertionCode, invalidValue) {
     return {
         code: wrap(assertionCode),
@@ -83,19 +87,20 @@ ruleTester.run("require-object-in-propequal", rule, {
     ],
 
     invalid: [
-        createInvalid("assert.propEqual(actual, 0);", "0"),
-        createInvalid("assert.propEqual(actual, -1);", "-1"),
-        createInvalid("assert.propEqual(actual, 'string');", "'string'"),
-        createInvalid("assert.propEqual(actual, `template`);", "`template`"),
-        createInvalid("assert.propEqual(actual, true);", "true"),
-        createInvalid("assert.propEqual(actual, false);", "false"),
-        createInvalid("assert.propEqual(actual, null);", "null"),
-        createInvalid("assert.propEqual(actual, /regex/);", "/regex/"),
-        createInvalid("assert.propEqual(actual, ++foo);", "++foo"),
-        createInvalid("assert.propEqual(actual, foo++);", "foo++"),
-        createInvalid("assert.propEqual(actual, --foo);", "--foo"),
-        createInvalid("assert.propEqual(actual, foo--);", "foo--"),
-        createInvalid("assert.propEqual(actual, <JSX />)", "<JSX />"),
-        createInvalid("assert.propEqual(actual, 0n);", "0n")
+        createInvalid(wrap("assert.propEqual(actual, 0);"), "0"),
+        createInvalid(wrapArrow("assert.propEqual(actual, 0);"), "0"),
+        createInvalid(wrap("assert.propEqual(actual, -1);"), "-1"),
+        createInvalid(wrap("assert.propEqual(actual, 'string');"), "'string'"),
+        createInvalid(wrap("assert.propEqual(actual, `template`);"), "`template`"),
+        createInvalid(wrap("assert.propEqual(actual, true);"), "true"),
+        createInvalid(wrap("assert.propEqual(actual, false);"), "false"),
+        createInvalid(wrap("assert.propEqual(actual, null);"), "null"),
+        createInvalid(wrap("assert.propEqual(actual, /regex/);"), "/regex/"),
+        createInvalid(wrap("assert.propEqual(actual, ++foo);"), "++foo"),
+        createInvalid(wrap("assert.propEqual(actual, foo++);"), "foo++"),
+        createInvalid(wrap("assert.propEqual(actual, --foo);"), "--foo"),
+        createInvalid(wrap("assert.propEqual(actual, foo--);"), "foo--"),
+        createInvalid(wrap("assert.propEqual(actual, <JSX />)"), "<JSX />"),
+        createInvalid(wrap("assert.propEqual(actual, 0n);"), "0n")
     ]
 });

--- a/tests/lib/rules/resolve-async.js
+++ b/tests/lib/rules/resolve-async.js
@@ -481,6 +481,11 @@ ruleTester.run("resolve-async", rule, {
             errors: [createAsyncCallbackNotCalledMessage("CallExpression")]
         },
         {
+            code: "QUnit.test('name', (foo) => { var done = foo.async(); });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [createAsyncCallbackNotCalledMessage("CallExpression")]
+        },
+        {
             code: "QUnit.module({ setup: function (foo) { var done = foo.async(); } });",
             errors: [createAsyncCallbackNotCalledMessage("Property")]
         }


### PR DESCRIPTION
Fixes #213
