### PR TITLE
Handle adding TypeScript type to `this` parameter in `test` hook in many rules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -227,8 +227,13 @@ exports.getAssertContextNameForTest = function (argumentsNodes) {
 exports.getAssertContextName = function (functionExpr) {
     let result;
 
-    if (functionExpr && functionExpr.params && functionExpr.params.length > 0) {
-        result = functionExpr.params[0].name;
+    if (functionExpr && functionExpr.params) {
+        // In TypeScript, `this` can be passed as the first function parameter to add a type to it,
+        // and we want to ignore that parameter since we're looking for the `hooks` variable.
+        const hooksParam = functionExpr.params.find(p => p.type === "Identifier" && p.name !== "this");
+        if (hooksParam) {
+            result = hooksParam.name;
+        }
     }
 
     return result;

--- a/tests/lib/rules/assert-args.js
+++ b/tests/lib/rules/assert-args.js
@@ -188,6 +188,18 @@ ruleTester.run("assert-args", rule, {
                 }
             }]
         },
+        {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.ok(); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "unexpectedArgCountNoMessage",
+                data: {
+                    callee: "assert.ok",
+                    argCount: 0
+                }
+            }]
+        },
         /* Allowed for now.
         {
             code: testUtils.wrapInTest("assert.ok(a, b);"),

--- a/tests/lib/rules/literal-compare-order.js
+++ b/tests/lib/rules/literal-compare-order.js
@@ -87,6 +87,19 @@ ruleTester.run("literal-compare-order", rule, {
             }]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: testUtils.wrapInTest("QUnit.test('test', (this: LocalTestContext) => { equal('Literal', variable); });"),
+            output: testUtils.wrapInTest("QUnit.test('test', (this: LocalTestContext) => { equal(variable, 'Literal'); });"),
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "actualFirst",
+                data: {
+                    expected: "'Literal'",
+                    actual: "variable"
+                }
+            }]
+        },
+        {
             code: testUtils.wrapInTest("equal('Literal', variable, 'message');"),
             output: testUtils.wrapInTest("equal(variable, 'Literal', 'message');"),
             errors: [{

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -67,6 +67,16 @@ ruleTester.run("no-arrow-tests", rule, {
             }]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.ok(true); });",
+            output: "QUnit.test('test', function(this: LocalTestContext, assert) { assert.ok(true); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "noArrowFunction",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
             code: "QUnit.test('test', () => { ok(true); });",
             output: "QUnit.test('test', function() { ok(true); });",
             errors: [{

--- a/tests/lib/rules/no-assert-equal-boolean.js
+++ b/tests/lib/rules/no-assert-equal-boolean.js
@@ -148,6 +148,14 @@ ruleTester.run("no-assert-equal-boolean", rule, {
             code: "QUnit.test('Name', function () { equal(a, true); });",
             output: "QUnit.test('Name', function () { true(a); });",
             errors: [{ messageId: "useAssertTrueOrFalse" }]
+        },
+
+        // TypeScript: test callback is adding a type to `this`
+        {
+            code: "QUnit.test('Name', function (this: LocalTestContext, assert) { assert.equal(a, true); });",
+            output: "QUnit.test('Name', function (this: LocalTestContext, assert) { assert.true(a); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{ messageId: "useAssertTrueOrFalse" }]
         }
     ]
 });

--- a/tests/lib/rules/no-assert-equal.js
+++ b/tests/lib/rules/no-assert-equal.js
@@ -31,6 +31,7 @@ ruleTester.run("no-assert-equal", rule, {
         "QUnit.test('Name', function () { strictEqual(a, b); });",
         "QUnit.test('Name', function () { deepEqual(a, b); });",
         "QUnit.test('Name', function () { propEqual(a, b); });",
+        "QUnit.test('Name', notAFunction);",
 
         // global `equal` but not within test context
         {
@@ -145,6 +146,29 @@ ruleTester.run("no-assert-equal", rule, {
                     {
                         messageId: "switchToStrictEqual",
                         output: "QUnit.test('Name', function () { strictEqual(a, b); });"
+                    }
+                ]
+            }]
+        },
+        {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('Name', function (this: LocalTestContext, assert) { assert.equal(a, b); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "unexpectedAssertEqual",
+                data: { assertVar: "assert" },
+                suggestions: [
+                    {
+                        messageId: "switchToDeepEqual",
+                        output: "QUnit.test('Name', function (this: LocalTestContext, assert) { assert.deepEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToPropEqual",
+                        output: "QUnit.test('Name', function (this: LocalTestContext, assert) { assert.propEqual(a, b); });"
+                    },
+                    {
+                        messageId: "switchToStrictEqual",
+                        output: "QUnit.test('Name', function (this: LocalTestContext, assert) { assert.strictEqual(a, b); });"
                     }
                 ]
             }]

--- a/tests/lib/rules/no-assert-logical-expression.js
+++ b/tests/lib/rules/no-assert-logical-expression.js
@@ -62,6 +62,20 @@ ruleTester.run("no-assert-logical-expression", rule, {
             }]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.ok(foo && bar); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "noLogicalOperator",
+                data: {
+                    operator: "&&"
+                },
+                type: "LogicalExpression",
+                line: 1,
+                column: 68
+            }]
+        },
+        {
             code: testUtils.wrapInArrowTest("assert.ok(foo && bar);"),
             parserOptions: { ecmaVersion: 6 },
             errors: [{

--- a/tests/lib/rules/no-async-in-loops.js
+++ b/tests/lib/rules/no-async-in-loops.js
@@ -499,6 +499,19 @@ ruleTester.run("no-async-in-loops", rule, {
             }]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "test('name', function (this: LocalTestContext, assert) { while (false) assert.async(); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "unexpectedAsyncInLoop",
+                data: {
+                    call: "assert.async()",
+                    loopTypeText: "while loop"
+                },
+                type: "CallExpression"
+            }]
+        },
+        {
             code: "test('name', (assert) => { while (false) assert.async(); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{

--- a/tests/lib/rules/no-compare-relation-boolean.js
+++ b/tests/lib/rules/no-compare-relation-boolean.js
@@ -54,6 +54,12 @@ ruleTester.run("no-compare-relation-boolean", rule, {
             output: testUtils.wrapInTest("assert.ok(a === b);")
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.equal(a === b, true); });",
+            output: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.ok(a === b); });",
+            parser: require.resolve("@typescript-eslint/parser")
+        },
+        {
             code: testUtils.wrapInArrowTest("assert.equal(a === b, true);"),
             output: testUtils.wrapInArrowTest("assert.ok(a === b);"),
             parserOptions: { ecmaVersion: 6 }

--- a/tests/lib/rules/no-early-return.js
+++ b/tests/lib/rules/no-early-return.js
@@ -53,6 +53,16 @@ ruleTester.run("no-early-return", rule, {
         },
 
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('a test', function (this: LocalTestContext, assert) { if (true) return; assert.ok(true); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "noEarlyReturn",
+                type: "ReturnStatement"
+            }]
+        },
+
+        {
             code: "QUnit.test('a test', (assert) => { if (true) return; assert.ok(true); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{

--- a/tests/lib/rules/no-negated-ok.js
+++ b/tests/lib/rules/no-negated-ok.js
@@ -105,6 +105,13 @@ ruleTester.run("no-negated-ok", rule, {
             errors: [createError("assert.ok")]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.ok(!foo); });",
+            output: "QUnit.test('test', (this: LocalTestContext, assert) => { assert.notOk(foo); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [createError("assert.ok")]
+        },
+        {
             code: testUtils.wrapInArrowTest("assert.ok(!foo)"),
             output: testUtils.wrapInArrowTest("assert.notOk(foo)"),
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/no-ok-equality.js
+++ b/tests/lib/rules/no-ok-equality.js
@@ -97,6 +97,15 @@ ruleTester.run("no-ok-equality", rule, {
             ]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "test('Name', function (this: LocalTestContext, assert) { assert.ok(x === 1); });",
+            output: "test('Name', function (this: LocalTestContext, assert) { assert.strictEqual(x, 1); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [
+                createError("assert.ok", "assert.strictEqual", "x", "1")
+            ]
+        },
+        {
             code: "test('Name', (assert) => { assert.ok(x === 1); });",
             output: "test('Name', (assert) => { assert.strictEqual(x, 1); });",
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/no-throws-string.js
+++ b/tests/lib/rules/no-throws-string.js
@@ -54,6 +54,18 @@ ruleTester.run("no-throws-string", rule, {
             }]
         },
         {
+            // TypeScript: test callback is adding a type to `this`
+            code: "QUnit.test('a test', function (this: LocalTestContext, assert) { assert.throws(function () { }, 'Error message', 'Error should have been thrown'); });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [{
+                messageId: "noThrowsWithString",
+                data: {
+                    callee: "assert.throws"
+                },
+                type: "CallExpression"
+            }]
+        },
+        {
             code: "QUnit.test('a test', (assert) => { assert.throws(function () { }, 'Error message', 'Error should have been thrown'); });",
             parserOptions: { ecmaVersion: 6 },
             errors: [{

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -61,6 +61,14 @@ ruleTester.run("require-expect", rule, {
             options: [] // Defaults to except-simple
         },
 
+        // default, using global expect, TS
+        {
+            // TypeScript: test callback is adding a type to `this`
+            code: "test('name', function(this: LocalTestContext) { expect(0) });",
+            options: [], // Defaults to except-simple
+            parser: require.resolve("@typescript-eslint/parser")
+        },
+
         // CallExpression without parent object throws no errors
         {
             code: "test('name', function(assert) { assert.expect(0); noParentObject() });",
@@ -147,6 +155,13 @@ ruleTester.run("require-expect", rule, {
             code: "test('name', (assert) => { other.assert.expect(0) });",
             options: ["always"],
             parserOptions: { ecmaVersion: 6 },
+            errors: [alwaysErrorMessage("assert.expect")]
+        },
+        {
+            // TypeScript: test callback is adding a type to `this`
+            code: "test('name', function(this: LocalTestContext, assert) { other.assert.expect(0) });",
+            options: ["always"],
+            parser: require.resolve("@typescript-eslint/parser"),
             errors: [alwaysErrorMessage("assert.expect")]
         },
 


### PR DESCRIPTION
Fixes #215. Uses the same fix that we used to fix https://github.com/platinumazure/eslint-plugin-qunit/issues/161.