### PR TITLE
Add jsdoc `type` annotation to rules

### DIFF
--- a/lib/rules/assert-args.js
+++ b/lib/rules/assert-args.js
@@ -15,6 +15,7 @@ const assert = require("assert"),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/lib/rules/literal-compare-order.js
+++ b/lib/rules/literal-compare-order.js
@@ -24,6 +24,7 @@ function swapFirstTwoNodesInList(sourceCode, fixer, list) {
     ];
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -16,6 +16,7 @@ const utils = require("../utils.js");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/lib/rules/no-assert-equal-boolean.js
+++ b/lib/rules/no-assert-equal-boolean.js
@@ -13,6 +13,7 @@ const assert = require("assert"),
 
 const EQUALITY_ASSERTIONS = new Set(["equal", "deepEqual", "strictEqual"]);
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -16,6 +16,7 @@ const assert = require("assert"),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-assert-logical-expression.js
+++ b/lib/rules/no-assert-logical-expression.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-assert-ok.js
+++ b/lib/rules/no-assert-ok.js
@@ -24,6 +24,7 @@ const ERROR_MESSAGE_CONFIG = {
         unexpectedLocalAssertionMessageId: LOCAL_ERROR_MESSAGE_ID }
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-async-in-loops.js
+++ b/lib/rules/no-async-in-loops.js
@@ -11,6 +11,7 @@ const assert = require("assert"),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-async-module-callbacks.js
+++ b/lib/rules/no-async-module-callbacks.js
@@ -22,6 +22,7 @@ function isAsyncFunctionExpression(node) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/lib/rules/no-async-test.js
+++ b/lib/rules/no-async-test.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-commented-tests.js
+++ b/lib/rules/no-commented-tests.js
@@ -8,6 +8,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -15,6 +15,7 @@ const assert = require("assert"),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-conditional-assertions.js
+++ b/lib/rules/no-conditional-assertions.js
@@ -26,6 +26,7 @@ const STOP_NODE_TYPES = new Set([
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-early-return.js
+++ b/lib/rules/no-early-return.js
@@ -15,6 +15,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -15,6 +15,7 @@ const { ReferenceTracker } = require("eslint-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -14,6 +14,7 @@ const { ReferenceTracker } = require("eslint-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -14,6 +14,7 @@ const { ReferenceTracker } = require("eslint-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -12,6 +12,7 @@ const { ReferenceTracker } = require("eslint-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/lib/rules/no-hooks-from-ancestor-modules.js
@@ -16,6 +16,7 @@ const utils = require("../utils");
 
 const NESTABLE_HOOK_NAMES = new Set(["afterEach", "beforeEach"]);
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -18,6 +18,7 @@ function findLast(arr, callback) {
     return [...arr].reverse().find(item => callback(item));
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-init.js
+++ b/lib/rules/no-init.js
@@ -10,6 +10,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-jsdump.js
+++ b/lib/rules/no-jsdump.js
@@ -8,6 +8,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -64,6 +64,7 @@ function parseOptions(options) {
     return [DEFAULT_ASSERTIONS, ERROR_MESSAGE_CONFIG];
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-negated-ok.js
+++ b/lib/rules/no-negated-ok.js
@@ -18,6 +18,7 @@ const ASSERTION_OPPOSITES = {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -10,6 +10,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-qunit-push.js
+++ b/lib/rules/no-qunit-push.js
@@ -8,6 +8,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-qunit-start-in-tests.js
+++ b/lib/rules/no-qunit-start-in-tests.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-qunit-stop.js
+++ b/lib/rules/no-qunit-stop.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-reassign-log-callbacks.js
+++ b/lib/rules/no-reassign-log-callbacks.js
@@ -10,6 +10,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-reset.js
+++ b/lib/rules/no-reset.js
@@ -10,6 +10,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-setup-teardown.js
+++ b/lib/rules/no-setup-teardown.js
@@ -12,6 +12,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-skip.js
+++ b/lib/rules/no-skip.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-test-expect-argument.js
+++ b/lib/rules/no-test-expect-argument.js
@@ -14,6 +14,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/no-throws-string.js
+++ b/lib/rules/no-throws-string.js
@@ -41,6 +41,7 @@ function isThrows(calleeNode, assertVar) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -11,6 +11,7 @@ const utils = require("../utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",

--- a/lib/rules/require-object-in-propequal.js
+++ b/lib/rules/require-object-in-propequal.js
@@ -15,6 +15,7 @@ const assert = require("assert"),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/lib/rules/resolve-async.js
+++ b/lib/rules/resolve-async.js
@@ -10,6 +10,7 @@
 
 const utils = require("../utils");
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "problem",

--- a/tests/index.js
+++ b/tests/index.js
@@ -85,6 +85,16 @@ describe("index.js", function () {
                     });
                 });
 
+                it("should have the right rule contents", function () {
+                    const path = `./lib/rules/${ruleName}.js`;
+                    const fileContents = fs.readFileSync(path, "utf8");
+
+                    assert.ok(
+                        fileContents.includes("/** @type {import('eslint').Rule.RuleModule} */"),
+                        "includes jsdoc comment for rule type"
+                    );
+                });
+
                 // eslint-disable-next-line complexity
                 it("should have the right doc contents", function () {
                     const path = `./docs/rules/${ruleName}.md`;


### PR DESCRIPTION
Supported by VSCode/Webstorm/other code editors. Uses TypeScript declaration to give JavaScript hints so code editors can provide information/autocomplete about various rule fields.

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#type

Idea from: https://github.com/eslint/generator-eslint/pull/113

<img width="391" alt="133895350-a19d0daf-593e-44b9-835f-bebf8b6a3d30" src="https://user-images.githubusercontent.com/698306/141347879-ec172c50-370e-4fb5-9a26-31f25853b851.png">
