### PR TITLE
Update "isQunitMethod" utils function to handle "test.<SomeQunitMethod>" test cases

### DIFF
--- a/docs/rules/no-only.md
+++ b/docs/rules/no-only.md
@@ -18,6 +18,8 @@ module.only('Name', function() { });
 
 only('Name', function() { });
 
+test.only('Name', function() { });
+
 ```
 
 The following patterns are not considered warnings:

--- a/docs/rules/no-skip.md
+++ b/docs/rules/no-skip.md
@@ -16,6 +16,8 @@ module.skip('Name', function() { });
 
 skip('Name', function() { });
 
+test.skip('Name', function() { });
+
 ```
 
 The following patterns are not considered warnings:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,8 +196,8 @@ function isQUnitMethod(calleeNode, qunitMethod) {
         result = calleeNode.name === qunitMethod;
     } else if (calleeNode.type === "MemberExpression" && calleeNode.property.type === "Identifier" && calleeNode.property.name === qunitMethod) {
         if (calleeNode.object.type === "Identifier") {
-            // QUnit.<qunitMethod>() or module.<qunitMethod>()
-            result = calleeNode.object.name === "QUnit" || calleeNode.object.name === "module";
+            // QUnit.<qunitMethod>() or module.<qunitMethod>(), or test.<qunitMethod>()
+            result = calleeNode.object.name === "QUnit" || calleeNode.object.name === "module" || calleeNode.object.name === "test";
         } else if (calleeNode.object.type === "MemberExpression") {
             // QUnit.*.<qunitMethod>()
             result = calleeNode.object.object.type === "Identifier" &&
@@ -241,7 +241,7 @@ exports.isAssertion = function (calleeNode, assertVar) {
 exports.getAllowedArities = function (calleeNode, assertVar) {
     const assertionMetadata = getAssertionMetadata(calleeNode, assertVar);
 
-    return assertionMetadata && assertionMetadata.allowedArities || /* istanbul ignore next */ [];
+    return assertionMetadata && assertionMetadata.allowedArities || /* istanbul ignore next */[];
 };
 
 exports.isComparativeAssertion = function (calleeNode, assertVar) {

--- a/tests/lib/rules/no-only.js
+++ b/tests/lib/rules/no-only.js
@@ -49,6 +49,12 @@ ruleTester.run("no-only", rule, {
             errors: [{
                 messageId: "noQUnitOnly"
             }]
+        },
+        {
+            code: "test.only('Name', function() { });",
+            errors: [{
+                messageId: "noQUnitOnly"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-skip.js
+++ b/tests/lib/rules/no-skip.js
@@ -50,6 +50,10 @@ ruleTester.run("no-skip", rule, {
         {
             code: "skip('Name', function() { });",
             errors: [createError("skip")]
+        },
+        {
+            code: "test.skip('Name', function() { });",
+            errors: [createError("test.skip")]
         }
     ]
 });


### PR DESCRIPTION
The isQunitMethod utils function will be updated to make the `test.\<someQunitMethod\>()` pattern detectable. The `no-skip` and `no-only` rules will also be updated according to this new detectable test case

BEFORE
```
  1) no-skip
       invalid
         test.skip('Name', function() { });:

      AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
      + expected - actual

      -0
      +1
```

AFTER
```
      ✔ test.skip('Name', function() { });
```
      
      
