### PR TITLE
add `allowFunctions` as an allow-list for require-expect function calls

### DIFF
--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -11,6 +11,18 @@ test. This rule checks for `expect` at linting time.
 
 ## Options
 
+This rule is configurable by  the `Check Type` and the `Config Options`
+
+### Check Type
+
+Example:
+
+```js
+rules: {
+  'qunit/require-expect': ['error', 'except-simple'],
+},
+```
+
 The "always" option requires that `expect` is called in each test.
 
 The "except-simple" (**default**) option only requires an `expect` call when an assertion is
@@ -27,6 +39,28 @@ option codifies such convention.
 The "never-except-zero" option disallows `except` calls, except when used to
 explicitly assert that a test performs no assertions, which would otherwise
 be considered an error.
+
+### Config Options
+
+This rule allows exactly one config option: `allowFunctions`
+
+#### allowFunctions
+
+If you are using the Check Type `except-simple` whenever you pass `assert` into
+another function you will cause an error. If you have some functions that you
+are passing `assert` to that don't add to the number of asserts (and maybe just
+extract the test name from the assert context) then you can mark those functions
+to be ok with the `allowFunctions` config option.
+
+Here is an example:
+
+```js
+rules: {
+  'qunit/require-expect': ['error', 'except-simple', {
+    allowFunctions: [ 'percySnapshot' ]
+  }],
+},
+```
 
 ## Rule Details
 

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -28,6 +28,15 @@ module.exports = {
         schema: [
             {
                 "enum": ["always", "except-simple", "never", "never-except-zero"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "allowFunctions": {
+                        "type": "array"
+                    }
+                },
+                "additionalProperties": false
             }
         ]
     },
@@ -67,7 +76,13 @@ module.exports = {
         }
 
         function isPassingAssertAsArgument(node) {
+            const allowedFunctions = context.options[1] && context.options[1].allowFunctions || [];
+
             if (!currentTest.assertName) {
+                return false;
+            }
+
+            if (allowedFunctions.includes(node.callee.name)) {
                 return false;
             }
 

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -141,6 +141,16 @@ ruleTester.run("require-expect", rule, {
         {
             code: "test('name', function(assert) { assert.expect(0) });",
             options: ["never-except-zero"]
+        },
+
+        // Sending assert to a function with a valid allowFunctions
+        {
+            code: [
+                "function myAssertion(a, assert, c) { assert.ok(true); }",
+                "test('name', function(assert) { myAssertion(null, assert, null); });"
+            ].join(returnAndIndent),
+            options: ["except-simple", { allowFunctions: ["myAssertion"] }],
+            errors: [exceptSimpleErrorMessage("assert.expect")]
         }
     ],
 


### PR DESCRIPTION
Hey folks 👋 

I was following the documentation for `@percy/ember` and they have an example that allows you to pass the `assert` argument into a `percySnapshot()` call to automatically interpret the test name and module name https://github.com/percy/percy-ember#qunit

But if you have `require-expect` configured with the default Check Type `except-simple` this will fail because you shouldn't pass `assert` to other functions.

I was thinking about it and I wanted to make use of this functionality in our application but I didn't want to disable the `require-expect` rule (or even change the current config of it). I considered doing an ignore for each case that I wanted to use this functionality but this just didn't seem right. I thought in the end the Best Solution™️ would be to have the ability to configure which functions I should allow you to pass `assert` into.

And this PR adds the ability to add a new config option to add an allow-list for passing `assert` into functions 🎉 

Let me know if you have any questions or if you would like me to change or improve this PR in any way 👍 