### PR TITLE
Fix no-compare-relation-boolean error when passing <2 args

### DIFF
--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -86,6 +86,9 @@ module.exports = {
 
         function checkAssertArguments(callExprNode) {
             const args = [...callExprNode.arguments];
+            if (args.length <= 2) {
+                return;
+            }
 
             const firstTwoArgsSorted = args.slice(0, 2).sort(sortLiteralFirst);
 

--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -86,7 +86,7 @@ module.exports = {
 
         function checkAssertArguments(callExprNode) {
             const args = [...callExprNode.arguments];
-            if (args.length <= 2) {
+            if (args.length < 2) {
                 return;
             }
 

--- a/tests/lib/rules/no-compare-relation-boolean.js
+++ b/tests/lib/rules/no-compare-relation-boolean.js
@@ -48,7 +48,8 @@ ruleTester.run("no-compare-relation-boolean", rule, {
         "assert.equal(a > b, c);",
 
         // Not enough arguments
-        "assert.strictEqual();"
+        "assert.strictEqual();",
+        "assert.strictEqual(a);"
     ].map(code => testUtils.wrapInTest(code)),
 
     invalid: [

--- a/tests/lib/rules/no-compare-relation-boolean.js
+++ b/tests/lib/rules/no-compare-relation-boolean.js
@@ -45,7 +45,10 @@ ruleTester.run("no-compare-relation-boolean", rule, {
 
         // Comparing against something that isn't a boolean literal is fine
         "assert.equal(a > b, 1);",
-        "assert.equal(a > b, c);"
+        "assert.equal(a > b, c);",
+
+        // Not enough arguments
+        "assert.strictEqual();"
     ].map(code => testUtils.wrapInTest(code)),
 
     invalid: [


### PR DESCRIPTION
My editor runs eslint on every change to the source file. When I type `assert.strictEqual(`, the editor autofills the closing paren. Then eslint crashes on the `no-compare-relation-boolean` rule with the error:
> TypeError: Cannot read properties of undefined (reading 'type')