### PR TITLE
fix: incorrectly-used violation message placeholders

### DIFF
--- a/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/lib/rules/no-hooks-from-ancestor-modules.js
@@ -28,7 +28,7 @@ module.exports = {
         },
         fixable: null,
         messages: {
-            "noHooksFromAncestorModules": "Do not call {{usedHooksIdentifierName}}.{{hookName}} from an ancestor module."
+            "noHooksFromAncestorModules": "Do not call {{usedHooksIdentifierName}}.{{invokedMethodName}} from an ancestor module."
         },
         schema: []
     },

--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -35,10 +35,7 @@ module.exports = {
                 if (utils.isOnly(node.callee)) {
                     context.report({
                         node: node,
-                        messageId: "noQUnitOnly",
-                        data: {
-                            callee: node.callee.name
-                        }
+                        messageId: "noQUnitOnly"
                     });
                 }
             }

--- a/lib/rules/no-skip.js
+++ b/lib/rules/no-skip.js
@@ -36,10 +36,7 @@ module.exports = {
                 if (utils.isSkip(node.callee)) {
                     context.report({
                         node: node,
-                        messageId: "noQUnitSkip",
-                        data: {
-                            callee: node.callee.name
-                        }
+                        messageId: "noQUnitSkip"
                     });
                 }
             }

--- a/tests/lib/rules/no-skip.js
+++ b/tests/lib/rules/no-skip.js
@@ -15,15 +15,6 @@ const rule = require("../../../lib/rules/no-skip"),
 // Tests
 //------------------------------------------------------------------------------
 
-function createError(callee) {
-    return {
-        messageId: "noQUnitSkip",
-        data: {
-            callee
-        }
-    };
-}
-
 const ruleTester = new RuleTester();
 
 ruleTester.run("no-skip", rule, {
@@ -37,23 +28,23 @@ ruleTester.run("no-skip", rule, {
     invalid: [
         {
             code: "QUnit.module.skip('Name', function() { });",
-            errors: [createError("QUnit.module.skip")]
+            errors: [{ messageId: "noQUnitSkip" }]
         },
         {
             code: "QUnit.skip('Name', function() { });",
-            errors: [createError("QUnit.skip")]
+            errors: [{ messageId: "noQUnitSkip" }]
         },
         {
             code: "module.skip('Name', function() { });",
-            errors: [createError("module.skip")]
+            errors: [{ messageId: "noQUnitSkip" }]
         },
         {
             code: "skip('Name', function() { });",
-            errors: [createError("skip")]
+            errors: [{ messageId: "noQUnitSkip" }]
         },
         {
             code: "test.skip('Name', function() { });",
-            errors: [createError("test.skip")]
+            errors: [{ messageId: "noQUnitSkip" }]
         }
     ]
 });


### PR DESCRIPTION
Fixing some lint violations detected by my WIP PR to update [eslint-plugin/no-missing-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-missing-placeholders.md) and [eslint-plugin/no-unused-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-unused-placeholders.md) to handle placeholders in messageIds:

* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/252

```
lib/rules/no-hooks-from-ancestor-modules.js
  31:43  error  The placeholder {{hookName}} does not exist      eslint-plugin/no-missing-placeholders
  31:43  error  The placeholder {{invokedMethodName}} is unused  eslint-plugin/no-unused-placeholders

lib/rules/no-only.js
  27:26  error  The placeholder {{callee}} is unused  eslint-plugin/no-unused-placeholders

lib/rules/no-skip.js
  28:26  error  The placeholder {{callee}} is unused  eslint-plugin/no-unused-placeholders
```
