### PR TITLE
chore: remove npm upgrade step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Upgrade npm
-      run: npm install -g npm
-
     - run: npm ci
     - run: npm run test:unit
     - run: npm install --save-dev eslint@7 && npm run test:unit


### PR DESCRIPTION
It looks like CI is currently failing because we upgrade npm during CI to a version no longer compatible with Node 12.

```
ERROR: npm v9.1.1 is known not to run on Node.js v12.22.12. You'll need to
upgrade to a newer Node.js version in order to use this version of npm. This
version of npm supports the following node versions: `^14.17.0 || ^1[6](https://github.com/platinumazure/eslint-plugin-qunit/actions/runs/3461679329/jobs/5779590138#step:5:7).13.0 ||
>=18.0.0`. You can find the latest version at [https://nodejs.org/.](https://nodejs.org/)
```

I don't know why we need to upgrade npm. Most CI scripts do not need to upgrade npm.

Upgrade step originally added here: https://github.com/platinumazure/eslint-plugin-qunit/commit/432744a177f636cfa5ce9202292ff12cfd9b9359