### PR TITLE
Fix false positives with arrow functions in `no-hooks-from-ancestor-modules` rule

### DIFF
--- a/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/lib/rules/no-hooks-from-ancestor-modules.js
@@ -63,7 +63,7 @@ module.exports = {
         function getCallbackArg(args) {
             // Callback can be either args[1] or args[2]
             // https://api.qunitjs.com/QUnit/module/
-            return args.slice(1, 3).find(arg => arg.type === "FunctionExpression");
+            return args.slice(1, 3).find(arg => ["FunctionExpression", "ArrowFunctionExpression"].includes(arg.type));
         }
 
         function getHooksIdentifierFromParams(params) {

--- a/tests/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/tests/lib/rules/no-hooks-from-ancestor-modules.js
@@ -45,6 +45,12 @@ ruleTester.run("no-hooks-from-ancestor-modules", rule, {
         QUnit.module("module", function(hooks) { hooks.beforeEach(function() {}); });
         `,
         `
+        QUnit.module("module", (hooks) => { hooks.beforeEach(() => {}); });
+        `,
+        `
+        QUnit.module("module", (hooks) => { QUnit.module("module", (hooks) => { hooks.beforeEach(() => {}); }) });
+        `,
+        `
         QUnit.module("module", function(hooks) { hooks.afterEach(function() {}); });
         `,
         `


### PR DESCRIPTION
This bug was caused by #267 which was attempting to fix #246.

The previous fix update the `FunctionExpression` check in one place but not the other.

CC: @platinumazure @bretjb