### PR TITLE
Docs: Correct GitHub access token variable name for releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 1. `git pull` the latest master and ensure that `git status` shows no local changes
 
-2. `export GITHUB_AUTH="..."` with a [GitHub access token](https://github.com/settings/tokens/new?scopes=repo&description=release-it) with "repo" access so [release-it](https://github.com/release-it/release-it) can conduct a GitHub release
+2. `export GITHUB_TOKEN="..."` with a [GitHub access token](https://github.com/settings/tokens/new?scopes=repo&description=release-it) with "repo" access so [release-it](https://github.com/release-it/release-it) can conduct a GitHub release
 
 3. `export EDITOR="vim"` to choose an editor for editing the changelog
 


### PR DESCRIPTION
release-it expects the GitHub access token to be set in the `GITHUB_TOKEN` environment variable.

`GITHUB_AUTH` is a far-less-common name for this variable that some repos manually choose.

https://github.com/release-it/release-it/blob/master/docs/github-releases.md#automated