### PR TITLE
Drop support for Node 12, 14, 17, 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3
@@ -42,6 +42,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "20.x"
       - run: npm ci
       - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": "12.x || 14.x || >=16.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "homepage": "https://github.com/platinumazure/eslint-plugin-qunit",
   "engines": {
-    "node": "12.x || 14.x || >=16.0.0"
+    "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
   },
   "release-it": {
     "github": {


### PR DESCRIPTION
BREAKING CHANGE

These are end-of-life: https://github.com/nodejs/release#release-schedule

Part of https://github.com/platinumazure/eslint-plugin-qunit/issues/222.