### PR TITLE
Strictly define Node API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "eslint-plugin-qunit",
   "version": "7.3.4",
   "description": "ESLint plugin containing rules useful for QUnit tests.",
-  "main": "index.js",
+  "exports": "./index.js",
+  "main": "./index.js",
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint \"**/*.md\"",


### PR DESCRIPTION
Part of https://github.com/platinumazure/eslint-plugin-qunit/issues/222.

This follows the lead of ESLint core and other ESLint plugins in strictly defining their Node API so that users cannot reach in and import/depend on arbitrary files inside the plugin.

* https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0#remove-lib
   > Beginning in v8.0.0, ESLint is strictly defining its public API. Previously, you could reach into individual files such as require("eslint/lib/rules/semi") and this is no longer allowed. There are a limited number of existing APIs that are now available through the /use-at-your-own-risk entrypoint for backwards compatibility, but these APIs are not formally supported and may break or disappear at any point in time.

https://nodejs.org/api/packages.html#main-entry-point-export

If anyone needs something that is no longer accessible, please file an issue to let us know and we can consider whether it's something that should be explicitly exported.


Related example: https://github.com/ember-cli/eslint-plugin-ember/pull/1514