### PR TITLE
Change `require-expect` rule default option to `never-except-zero`

### DIFF
--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -15,7 +15,7 @@ test. This rule checks for `expect` at linting time.
 
 The "always" option requires that `expect` is called in each test.
 
-The "except-simple" (**default**) option only requires an `expect` call when an assertion is
+The "except-simple" option only requires an `expect` call when an assertion is
 called inside of a block or when `assert` is passed to another function. The
 rationale here is that by wrapping `assert` statements in conditional blocks
 or callbacks, developers are at risk of creating tests that incorrectly pass
@@ -26,7 +26,7 @@ resilience in QUnit 2.0 for tracking asynchronous activity, projects may
 prefer to discourage use of redundant `assert.expect` calls in tests. This
 option codifies such convention.
 
-The "never-except-zero" option disallows `except` calls, except when used to
+The "never-except-zero" option (**default**) disallows `except` calls, except when used to
 explicitly assert that a test performs no assertions, which would otherwise
 be considered an error.
 

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -214,6 +214,6 @@ module.exports = {
             "except-simple": ExceptSimpleStrategy,
             "never": NeverStrategy,
             "never-except-zero": NeverExceptZeroStrategy
-        }[context.options[0]] || ExceptSimpleStrategy;
+        }[context.options[0]] || NeverExceptZeroStrategy;
     }
 };

--- a/tests/lib/rules/require-expect.js
+++ b/tests/lib/rules/require-expect.js
@@ -52,27 +52,27 @@ ruleTester.run("require-expect", rule, {
         // default, calling expect is valid
         {
             code: "test('name', function(assert) { assert.expect(0) });",
-            options: [] // Defaults to except-simple
+            options: [] // Defaults to never-except-zero
         },
 
         // default, using global expect
         {
             code: "test('name', function() { expect(0) });",
-            options: [] // Defaults to except-simple
+            options: [] // Defaults to never-except-zero
         },
 
         // default, using global expect, TS
         {
             // TypeScript: test callback is adding a type to `this`
             code: "test('name', function(this: LocalTestContext) { expect(0) });",
-            options: [], // Defaults to except-simple
+            options: [], // Defaults to never-except-zero
             parser: require.resolve("@typescript-eslint/parser")
         },
 
         // CallExpression without parent object throws no errors
         {
             code: "test('name', function(assert) { assert.expect(0); noParentObject() });",
-            options: [] // Defaults to except-simple
+            options: [] // Defaults to never-except-zero
         },
         {
             code: "test('name', function(assert) { assert.expect(0); noParentObject() });",
@@ -91,7 +91,7 @@ ruleTester.run("require-expect", rule, {
         },
         {
             code: "test('name', function(assert) { assert.ok(true) });",
-            options: [] // Defaults to except-simple
+            options: [] // Defaults to never-except-zero
         },
 
         // global assertion at top of test context is ok
@@ -192,11 +192,6 @@ ruleTester.run("require-expect", rule, {
         {
             code: "test('name', function(assert) { while (false) { assert.ok(true) } });",
             options: ["except-simple"],
-            errors: [exceptSimpleErrorMessage("assert.expect")]
-        },
-        {
-            code: "test('name', function(assert) { while (false) { assert.ok(true) } });",
-            options: [], // Defaults to except-simple
             errors: [exceptSimpleErrorMessage("assert.expect")]
         },
 
@@ -409,6 +404,11 @@ ruleTester.run("require-expect", rule, {
         {
             code: "test('name', function(assert) { assert.expect(1); assert.ok(true); });",
             options: ["never-except-zero"],
+            errors: [neverErrorMessage("assert.expect")]
+        },
+        {
+            code: "test('name', function(assert) { assert.expect(1); assert.ok(true); });",
+            options: [], // defaults to never-except-zero
             errors: [neverErrorMessage("assert.expect")]
         }
     ]


### PR DESCRIPTION
Discussion here: https://github.com/platinumazure/eslint-plugin-qunit/issues/222#issuecomment-1031800401

Part of https://github.com/platinumazure/eslint-plugin-qunit/issues/222.