### PR TITLE
Tweak release-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,18 @@
     },
     "plugins": {
       "@release-it/conventional-changelog": {
-        "preset": "eslint",
+        "preset": {
+          "name": "conventionalcommits",
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "chore", "section": "Chores" },
+            { "type": "refactor", "section": "Chores" },
+            { "type": "test", "section": "Chores" }
+          ]
+        },
         "infile": "CHANGELOG.md"
       }
     }


### PR DESCRIPTION
The `eslint` preset doesn't work well and doesn't appear to have any configurability.

I am switching to the `conventionalcommits` preset which is more popular and reliable.

I enabled the common prefixes/sections we use with it, while intentionally excluding "upgrade" which would add a lot of dependabot spam to the changelog.

This preset appears to do a better job with:
* Picking the right version to use for the release based on semver (overridable with `npm run release -- --i major`)
* Grouping the commits into sections for the changelog
   * I also opened https://github.com/release-it/conventional-changelog/issues/63 because I was hoping we could manually edit the changelog when needed

I did a dry-run to test and the results look better.

More info:
* https://github.com/release-it/conventional-changelog

Fixes #220.