### PR TITLE
Fix default in doc for `require-expect` rule

### DIFF
--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -59,7 +59,7 @@ test('name', function() {
 
 ### except-simple
 
-When using the **default** "except-simple" option, the following patterns are considered
+When using the "except-simple" option, the following patterns are considered
 warnings.
 
 ```js
@@ -158,7 +158,7 @@ test('name', function(assert) {
 
 ### never-except-zero
 
-The following would warn.
+When using the **default** "never-except-zero" option, the following would warn.
 
 ```js
 test('name', function(assert) {


### PR DESCRIPTION
Follow-up to #375.

I missed one update to the doc.