### PR TITLE
docs: auto-generate readme configs list and some rule doc options lists with eslint-doc-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ You can extend from a configuration in order to simplify manual configuration of
 
 For more details on how to extend your configuration from a plugin configuration, please see the [ESLint plugin configuration documentation](https://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin).
 
-|     | Name | Description |
-| :-- | :--- | :---------- |
-| ✅ | recommended | This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. You can use this configuration by extending from `"plugin:qunit/recommended"` in your configuration file. |
+<!-- begin auto-generated configs list -->
+
+|    | Name          | Description                                                                                                                                                                                                                                                                                                                                        |
+| :- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅  | `recommended` | This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. You can use this configuration by extending from `"plugin:qunit/recommended"` in your configuration file. |
+
+<!-- end auto-generated configs list -->
 
 ## Rules
 

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -66,9 +66,13 @@ QUnit.test("Name", function (assert) { assert.ok(x instanceof Number); });
 
 ## Options
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-* `allowGlobals` (boolean, default: true): Whether the rule should check global assertions
+| Name          | Description                                      | Type    | Default |
+| :------------ | :----------------------------------------------- | :------ | :------ |
+| `allowGlobal` | Whether the rule should check global assertions. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->
 
 ## When Not to Use It
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     // eslint-disable-next-line sort-keys
     configs: {
         recommended: {
+            description: "This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. You can use this configuration by extending from `\"plugin:qunit/recommended\"` in your configuration file.",
             plugins: ["qunit"],
             rules: {
                 "qunit/assert-args": "error",

--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -28,7 +28,9 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowGlobal: {
-                        type: "boolean"
+                        type: "boolean",
+                        description: "Whether the rule should check global assertions.",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chai": "^4.3.10",
         "coveralls": "^3.1.1",
         "eslint": "^8.51.0",
-        "eslint-doc-generator": "^1.4.3",
+        "eslint-doc-generator": "^1.5.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-eslint-plugin": "^5.1.1",
         "eslint-plugin-markdown": "^3.0.1",
@@ -3692,9 +3692,9 @@
       }
     },
     "node_modules/eslint-doc-generator": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-doc-generator/-/eslint-doc-generator-1.4.3.tgz",
-      "integrity": "sha512-cn9KXE7xuKlxKi/9VbirR3cbz7W1geRObwWzZjJAnpTeNBoqA8Rj+lD8/HHHJ7PnOdaTrRyhhoYdCtxqq3U7Bw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-doc-generator/-/eslint-doc-generator-1.5.1.tgz",
+      "integrity": "sha512-ZkVsI2AXXljiZ3xVsEv4yIrcXby0xj43ID/uYBZSuZJd3rQ4KZge3BxHg4NKJxfWkNMqarGudxMo8uPkTRfYbw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.38.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^4.3.10",
     "coveralls": "^3.1.1",
     "eslint": "^8.51.0",
-    "eslint-doc-generator": "^1.4.3",
+    "eslint-doc-generator": "^1.5.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^5.1.1",
     "eslint-plugin-markdown": "^3.0.1",


### PR DESCRIPTION
Note that I have only added these auto-generated rule doc option lists to rules with simple object-based options. Other types of options (enums/arrays/etc) aren't supported yet.

These features shipped in:
* https://github.com/bmish/eslint-doc-generator/releases/tag/v1.5.0
* https://github.com/bmish/eslint-doc-generator/pull/480