### PR TITLE
ci: Use parallel coveralls config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
     - run: npm run test:unit
 
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./build/coverage/lcov.info
+        parallel: true
 
   lint:
     runs-on: ubuntu-latest
@@ -44,3 +45,12 @@ jobs:
           node-version: "20.x"
       - run: npm ci
       - run: npm run lint
+
+  finish-coveralls:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v1
+        with:
+          parallel-finished: true


### PR DESCRIPTION
Noticed that a bunch of the upgrade PRs are failing with the occasional coveralls "build is closed" error. So I configured for parallel coveralls jobs for now. (Maybe running coverage on only latest Node would be better, though.)

Reference: https://docs.coveralls.io/parallel-builds