### PR TITLE
chore: Change master branch references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   push:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '32 15 * * 2'
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/eslint-plugin-qunit.svg?style=flat)](https://npmjs.org/package/eslint-plugin-qunit)
 ![CI](https://github.com/platinumazure/eslint-plugin-qunit/workflows/CI/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/platinumazure/eslint-plugin-qunit/badge.svg?branch=master&service=github)](https://coveralls.io/github/platinumazure/eslint-plugin-qunit?branch=master)
+[![Coverage Status](https://coveralls.io/repos/platinumazure/eslint-plugin-qunit/badge.svg?branch=main&service=github)](https://coveralls.io/github/platinumazure/eslint-plugin-qunit?branch=main)
 [![Join the chat at https://gitter.im/platinumazure/eslint-plugin-qunit](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/platinumazure/eslint-plugin-qunit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ESLint plugin containing rules useful for QUnit tests.
@@ -25,8 +25,8 @@ For more details on how to extend your configuration from a plugin configuration
 
 <!-- begin auto-generated rules list -->
 
-💼 [Configurations](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations) enabled in.\
-✅ Set in the `recommended` [configuration](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).\
+💼 [Configurations](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations) enabled in.\
+✅ Set in the `recommended` [configuration](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Instructions
 
-1. `git pull` the latest master and ensure that `git status` shows no local changes
+1. `git pull` the latest commits in the `main` branch and ensure that `git status` shows no local changes
 
 2. `export GITHUB_TOKEN="..."` with a [GitHub access token](https://github.com/settings/tokens/new?scopes=repo&description=release-it) with "repo" access so [release-it](https://github.com/release-it/release-it) can conduct a GitHub release
 

--- a/docs/rules/assert-args.md
+++ b/docs/rules/assert-args.md
@@ -1,6 +1,6 @@
 # Enforce that the correct number of assert arguments are used (`qunit/assert-args`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/literal-compare-order.md
+++ b/docs/rules/literal-compare-order.md
@@ -1,6 +1,6 @@
 # Enforce comparison assertions have arguments in the right order (`qunit/literal-compare-order`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-assert-equal-boolean.md
+++ b/docs/rules/no-assert-equal-boolean.md
@@ -1,6 +1,6 @@
 # Require use of boolean assertions (`qunit/no-assert-equal-boolean`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-assert-equal.md
+++ b/docs/rules/no-assert-equal.md
@@ -1,6 +1,6 @@
 # Disallow the use of assert.equal (`qunit/no-assert-equal`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/no-assert-logical-expression.md
+++ b/docs/rules/no-assert-logical-expression.md
@@ -1,6 +1,6 @@
 # Disallow binary logical expressions in assert arguments (`qunit/no-assert-logical-expression`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-async-in-loops.md
+++ b/docs/rules/no-async-in-loops.md
@@ -1,6 +1,6 @@
 # Disallow async calls in loops (`qunit/no-async-in-loops`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-async-module-callbacks.md
+++ b/docs/rules/no-async-module-callbacks.md
@@ -1,6 +1,6 @@
 # Disallow async module callbacks (`qunit/no-async-module-callbacks`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-async-test.md
+++ b/docs/rules/no-async-test.md
@@ -1,6 +1,6 @@
 # Disallow the use of asyncTest or QUnit.asyncTest (`qunit/no-async-test`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-commented-tests.md
+++ b/docs/rules/no-commented-tests.md
@@ -1,6 +1,6 @@
 # Disallow commented tests (`qunit/no-commented-tests`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-compare-relation-boolean.md
+++ b/docs/rules/no-compare-relation-boolean.md
@@ -1,6 +1,6 @@
 # Disallow comparing relational expressions to booleans in assertions (`qunit/no-compare-relation-boolean`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-conditional-assertions.md
+++ b/docs/rules/no-conditional-assertions.md
@@ -1,6 +1,6 @@
 # Disallow assertions within if statements or conditional expressions (`qunit/no-conditional-assertions`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-early-return.md
+++ b/docs/rules/no-early-return.md
@@ -1,6 +1,6 @@
 # Disallow early return in tests (`qunit/no-early-return`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-global-assertions.md
+++ b/docs/rules/no-global-assertions.md
@@ -1,6 +1,6 @@
 # Disallow global QUnit assertions (`qunit/no-global-assertions`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-global-expect.md
+++ b/docs/rules/no-global-expect.md
@@ -1,6 +1,6 @@
 # Disallow global expect (`qunit/no-global-expect`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-global-module-test.md
+++ b/docs/rules/no-global-module-test.md
@@ -1,6 +1,6 @@
 # Disallow global module/test/asyncTest (`qunit/no-global-module-test`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-global-stop-start.md
+++ b/docs/rules/no-global-stop-start.md
@@ -1,6 +1,6 @@
 # Disallow global stop/start (`qunit/no-global-stop-start`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-hooks-from-ancestor-modules.md
+++ b/docs/rules/no-hooks-from-ancestor-modules.md
@@ -1,6 +1,6 @@
 # Disallow the use of hooks from ancestor modules (`qunit/no-hooks-from-ancestor-modules`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-identical-names.md
+++ b/docs/rules/no-identical-names.md
@@ -1,6 +1,6 @@
 # Disallow identical test and module names (`qunit/no-identical-names`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-init.md
+++ b/docs/rules/no-init.md
@@ -1,6 +1,6 @@
 # Disallow use of QUnit.init (`qunit/no-init`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-jsdump.md
+++ b/docs/rules/no-jsdump.md
@@ -1,6 +1,6 @@
 # Disallow use of QUnit.jsDump (`qunit/no-jsdump`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-negated-ok.md
+++ b/docs/rules/no-negated-ok.md
@@ -1,6 +1,6 @@
 # Disallow negation in assert.ok/assert.notOk (`qunit/no-negated-ok`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -1,6 +1,6 @@
 # Disallow nested QUnit.test() calls (`qunit/no-nested-tests`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-ok-equality.md
+++ b/docs/rules/no-ok-equality.md
@@ -1,6 +1,6 @@
 # Disallow equality comparisons in assert.ok/assert.notOk (`qunit/no-ok-equality`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-only.md
+++ b/docs/rules/no-only.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.only (`qunit/no-only`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-qunit-push.md
+++ b/docs/rules/no-qunit-push.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.push (`qunit/no-qunit-push`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-qunit-start-in-tests.md
+++ b/docs/rules/no-qunit-start-in-tests.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.start() within tests or test hooks (`qunit/no-qunit-start-in-tests`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-qunit-stop.md
+++ b/docs/rules/no-qunit-stop.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.stop (`qunit/no-qunit-stop`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-reassign-log-callbacks.md
+++ b/docs/rules/no-reassign-log-callbacks.md
@@ -1,6 +1,6 @@
 # Disallow overwriting of QUnit logging callbacks (`qunit/no-reassign-log-callbacks`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-reset.md
+++ b/docs/rules/no-reset.md
@@ -1,6 +1,6 @@
 # Disallow QUnit.reset (`qunit/no-reset`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-setup-teardown.md
+++ b/docs/rules/no-setup-teardown.md
@@ -1,6 +1,6 @@
 # Disallow setup/teardown module hooks (`qunit/no-setup-teardown`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-test-expect-argument.md
+++ b/docs/rules/no-test-expect-argument.md
@@ -1,6 +1,6 @@
 # Disallow the expect argument in QUnit.test (`qunit/no-test-expect-argument`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-throws-string.md
+++ b/docs/rules/no-throws-string.md
@@ -1,6 +1,6 @@
 # Disallow assert.throws() with block, string, and message args (`qunit/no-throws-string`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/require-expect.md
+++ b/docs/rules/require-expect.md
@@ -1,6 +1,6 @@
 # Enforce that `expect` is called (`qunit/require-expect`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/require-object-in-propequal.md
+++ b/docs/rules/require-object-in-propequal.md
@@ -1,6 +1,6 @@
 # Enforce use of objects as expected value in `assert.propEqual` (`qunit/require-object-in-propequal`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/resolve-async.md
+++ b/docs/rules/resolve-async.md
@@ -1,6 +1,6 @@
 # Require that async calls are resolved (`qunit/resolve-async`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations).
 
 <!-- end auto-generated rule header -->
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,7 +165,7 @@ module.exports = [
                 "error",
                 {
                     pattern:
-                        "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/{{name}}.md",
+                        "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/{{name}}.md",
                 },
             ],
 

--- a/lib/rules/assert-args.js
+++ b/lib/rules/assert-args.js
@@ -23,7 +23,7 @@ module.exports = {
             description:
                 "enforce that the correct number of assert arguments are used",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/assert-args.md",
         },
         messages: {
             unexpectedArgCount:

--- a/lib/rules/literal-compare-order.js
+++ b/lib/rules/literal-compare-order.js
@@ -32,7 +32,7 @@ module.exports = {
             description:
                 "enforce comparison assertions have arguments in the right order",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/literal-compare-order.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/literal-compare-order.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-arrow-tests.js
+++ b/lib/rules/no-arrow-tests.js
@@ -24,7 +24,7 @@ module.exports = {
             description:
                 "disallow arrow functions as QUnit test/module callbacks",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-arrow-tests.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-assert-equal-boolean.js
+++ b/lib/rules/no-assert-equal-boolean.js
@@ -20,7 +20,7 @@ module.exports = {
         docs: {
             description: "require use of boolean assertions",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal-boolean.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-assert-equal-boolean.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -23,7 +23,7 @@ module.exports = {
         docs: {
             description: "disallow the use of assert.equal",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-assert-equal.md",
         },
         messages: {
             unexpectedGlobalEqual:

--- a/lib/rules/no-assert-logical-expression.js
+++ b/lib/rules/no-assert-logical-expression.js
@@ -23,7 +23,7 @@ module.exports = {
                 "disallow binary logical expressions in assert arguments",
             category: "Best Practices",
             recommended: false,
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-logical-expression.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-assert-logical-expression.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-async-in-loops.js
+++ b/lib/rules/no-async-in-loops.js
@@ -18,7 +18,7 @@ module.exports = {
         docs: {
             description: "disallow async calls in loops",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-in-loops.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-async-in-loops.md",
         },
         messages: {
             unexpectedAsyncInLoop: "Unexpected {{call}} in {{loopTypeText}}.",

--- a/lib/rules/no-async-module-callbacks.js
+++ b/lib/rules/no-async-module-callbacks.js
@@ -33,7 +33,7 @@ module.exports = {
             description: "disallow async module callbacks",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-module-callbacks.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-async-module-callbacks.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-async-test.js
+++ b/lib/rules/no-async-test.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow the use of asyncTest or QUnit.asyncTest",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-async-test.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-async-test.md",
         },
         messages: {
             unexpectedAsyncTest:

--- a/lib/rules/no-commented-tests.js
+++ b/lib/rules/no-commented-tests.js
@@ -15,7 +15,7 @@ module.exports = {
         docs: {
             description: "disallow commented tests",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-commented-tests.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-commented-tests.md",
         },
         messages: {
             unexpectedTestInComment:

--- a/lib/rules/no-compare-relation-boolean.js
+++ b/lib/rules/no-compare-relation-boolean.js
@@ -23,7 +23,7 @@ module.exports = {
             description:
                 "disallow comparing relational expressions to booleans in assertions",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-compare-relation-boolean.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-compare-relation-boolean.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-conditional-assertions.js
+++ b/lib/rules/no-conditional-assertions.js
@@ -38,7 +38,7 @@ module.exports = {
                 "disallow assertions within if statements or conditional expressions",
             category: "Best Practices",
             recommended: false,
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-conditional-assertions.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-conditional-assertions.md",
         },
         fixable: null, // or "code" or "whitespace"
         messages: {

--- a/lib/rules/no-early-return.js
+++ b/lib/rules/no-early-return.js
@@ -22,7 +22,7 @@ module.exports = {
         docs: {
             description: "disallow early return in tests",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-early-return.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-early-return.md",
         },
         messages: {
             noEarlyReturn: "Do not return early from a QUnit test.",

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -22,7 +22,7 @@ module.exports = {
         docs: {
             description: "disallow global QUnit assertions",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-assertions.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-global-assertions.md",
         },
         messages: {
             unexpectedGlobalAssertion:

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow global expect",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-expect.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-global-expect.md",
         },
         messages: {
             unexpectedGlobalExpect: "Unexpected global expect.",

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow global module/test/asyncTest",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-module-test.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-global-module-test.md",
         },
         messages: {
             unexpectedGlobalModuleTest: "Unexpected global `{{ callee }}`.",

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -19,7 +19,7 @@ module.exports = {
         docs: {
             description: "disallow global stop/start",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-global-stop-start.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-global-stop-start.md",
         },
         messages: {
             unexpectedGlobalStopStart: "Unexpected global {{callee}}() call.",

--- a/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/lib/rules/no-hooks-from-ancestor-modules.js
@@ -24,7 +24,7 @@ module.exports = {
             description: "disallow the use of hooks from ancestor modules",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-hooks-from-ancestor-modules.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-hooks-from-ancestor-modules.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-identical-names.js
+++ b/lib/rules/no-identical-names.js
@@ -25,7 +25,7 @@ module.exports = {
         docs: {
             description: "disallow identical test and module names",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-identical-names.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-identical-names.md",
         },
         messages: {
             duplicateTest:

--- a/lib/rules/no-init.js
+++ b/lib/rules/no-init.js
@@ -17,7 +17,7 @@ module.exports = {
         docs: {
             description: "disallow use of QUnit.init",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-init.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-init.md",
         },
         messages: {
             noInit: "Do not use QUnit.init().",

--- a/lib/rules/no-jsdump.js
+++ b/lib/rules/no-jsdump.js
@@ -15,7 +15,7 @@ module.exports = {
         docs: {
             description: "disallow use of QUnit.jsDump",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-jsdump.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-jsdump.md",
         },
         messages: {
             noJsDump: "Use QUnit.dump() instead of QUnit.jsDump().",

--- a/lib/rules/no-loose-assertions.js
+++ b/lib/rules/no-loose-assertions.js
@@ -86,7 +86,7 @@ module.exports = {
             description:
                 "disallow the use of assert.equal/assert.ok/assert.notEqual/assert.notOk",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-loose-assertions.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-loose-assertions.md",
         },
         messages: {
             [GLOBAL_ERROR_MESSAGE_ID]:

--- a/lib/rules/no-negated-ok.js
+++ b/lib/rules/no-negated-ok.js
@@ -25,7 +25,7 @@ module.exports = {
         docs: {
             description: "disallow negation in assert.ok/assert.notOk",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-negated-ok.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-negated-ok.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow nested QUnit.test() calls",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-nested-tests.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-nested-tests.md",
         },
         messages: {
             noNestedTests:

--- a/lib/rules/no-ok-equality.js
+++ b/lib/rules/no-ok-equality.js
@@ -18,7 +18,7 @@ module.exports = {
             description:
                 "disallow equality comparisons in assert.ok/assert.notOk",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-ok-equality.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-ok-equality.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow QUnit.only",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-only.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-only.md",
         },
         messages: {
             noQUnitOnly: "Unexpected only() call.",

--- a/lib/rules/no-qunit-push.js
+++ b/lib/rules/no-qunit-push.js
@@ -15,7 +15,7 @@ module.exports = {
         docs: {
             description: "disallow QUnit.push",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-push.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-qunit-push.md",
         },
         messages: {
             noQUnitPush: "Do not use QUnit.push().",

--- a/lib/rules/no-qunit-start-in-tests.js
+++ b/lib/rules/no-qunit-start-in-tests.js
@@ -22,7 +22,7 @@ module.exports = {
             description: "disallow QUnit.start() within tests or test hooks",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-start-in-tests.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-qunit-start-in-tests.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-qunit-stop.js
+++ b/lib/rules/no-qunit-stop.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow QUnit.stop",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-qunit-stop.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-qunit-stop.md",
         },
         messages: {
             noQUnitStop: "Use assert.async() instead of QUnit.stop().",

--- a/lib/rules/no-reassign-log-callbacks.js
+++ b/lib/rules/no-reassign-log-callbacks.js
@@ -17,7 +17,7 @@ module.exports = {
         docs: {
             description: "disallow overwriting of QUnit logging callbacks",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-reassign-log-callbacks.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-reassign-log-callbacks.md",
         },
         messages: {
             noReassignLogCallbacks: "Do not reassign QUnit log callbacks.",

--- a/lib/rules/no-reset.js
+++ b/lib/rules/no-reset.js
@@ -17,7 +17,7 @@ module.exports = {
         docs: {
             description: "disallow QUnit.reset",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-reset.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-reset.md",
         },
         messages: {
             noReset: "Do not use QUnit.reset().",

--- a/lib/rules/no-setup-teardown.js
+++ b/lib/rules/no-setup-teardown.js
@@ -19,7 +19,7 @@ module.exports = {
         docs: {
             description: "disallow setup/teardown module hooks",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-setup-teardown.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-setup-teardown.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/no-skip.js
+++ b/lib/rules/no-skip.js
@@ -22,7 +22,7 @@ module.exports = {
             description: "disallow QUnit.skip",
             category: "Best Practices",
             recommended: false,
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-skip.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-skip.md",
         },
         messages: {
             noQUnitSkip: "Unexpected skip() call.",

--- a/lib/rules/no-test-expect-argument.js
+++ b/lib/rules/no-test-expect-argument.js
@@ -21,7 +21,7 @@ module.exports = {
         docs: {
             description: "disallow the expect argument in QUnit.test",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-test-expect-argument.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-test-expect-argument.md",
         },
         messages: {
             noExpectArgument: "Do not use expect argument in {{callee}}().",

--- a/lib/rules/no-throws-string.js
+++ b/lib/rules/no-throws-string.js
@@ -50,7 +50,7 @@ module.exports = {
             description:
                 "disallow assert.throws() with block, string, and message args",
             category: "Possible errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-throws-string.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/no-throws-string.md",
         },
         messages: {
             noThrowsWithString: "Do not use {{callee}}(block, string, string).",

--- a/lib/rules/require-expect.js
+++ b/lib/rules/require-expect.js
@@ -18,7 +18,7 @@ module.exports = {
         docs: {
             description: "enforce that `expect` is called",
             category: "Best Practices",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/require-expect.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/require-expect.md",
         },
         messages: {
             expectRequired: "Test is missing `{{expect}}()` call.",

--- a/lib/rules/require-object-in-propequal.js
+++ b/lib/rules/require-object-in-propequal.js
@@ -23,7 +23,7 @@ module.exports = {
             description:
                 "enforce use of objects as expected value in `assert.propEqual`",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/require-object-in-propequal.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/require-object-in-propequal.md",
         },
         messages: {
             useObject:

--- a/lib/rules/resolve-async.js
+++ b/lib/rules/resolve-async.js
@@ -17,7 +17,7 @@ module.exports = {
         docs: {
             description: "require that async calls are resolved",
             category: "Possible Errors",
-            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/resolve-async.md",
+            url: "https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/resolve-async.md",
         },
         messages: {
             needMoreStartCalls:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "release": "release-it",
     "test": "npm-run-all lint test:unit",
     "test:unit": "nyc mocha tests/**/*.js",
-    "update:eslint-docs": "eslint-doc-generator --url-configs \"https://github.com/platinumazure/eslint-plugin-qunit/blob/master/README.md#configurations\""
+    "update:eslint-docs": "eslint-doc-generator --url-configs \"https://github.com/platinumazure/eslint-plugin-qunit/blob/main/README.md#configurations\""
   },
   "files": [
     "index.js",


### PR DESCRIPTION
I've changed the master branch to main branch. (Contributors should learn this when they next visit the repository and should be provided with commands to run locally, if needed.)

This PR explicitly updates references to the master branch to use the new name `main`.

(Reference: https://github.com/github/renaming)