### PR TITLE
fix: remove disallowed description property from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,9 @@ You can extend from a configuration in order to simplify manual configuration of
 
 For more details on how to extend your configuration from a plugin configuration, please see the [ESLint plugin configuration documentation](https://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin).
 
-<!-- begin auto-generated configs list -->
-
-|    | Name          | Description                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| :- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| | Name | Description |
+| :--- | :--- | :--- |
 | ✅  | `recommended` | This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you. For ESLint `.eslintrc.js` legacy config, extend from `"plugin:qunit/recommended"`. For ESLint `eslint.config.js` flat config, load from `require('eslint-plugin-qunit/configs/recommended')`. |
-
-<!-- end auto-generated configs list -->
 
 ## Rules
 

--- a/index.js
+++ b/index.js
@@ -21,11 +21,6 @@ module.exports = {
     // eslint-disable-next-line sort-keys
     configs: {
         recommended: {
-            description: [
-                "This configuration includes rules which I recommend to avoid QUnit runtime errors or incorrect behavior, some of which can be difficult to debug. Some of these rules also encourage best practices that help QUnit work better for you.",
-                'For ESLint `.eslintrc.js` legacy config, extend from `"plugin:qunit/recommended"`.',
-                "For ESLint `eslint.config.js` flat config, load from `require('eslint-plugin-qunit/configs/recommended')`.",
-            ].join(" "),
             plugins: ["qunit"],
             rules: {
                 "qunit/assert-args": "error",


### PR DESCRIPTION
Fixes this comment:
* https://github.com/platinumazure/eslint-plugin-qunit/pull/443#issuecomment-1937479754

Context:
* https://github.com/bmish/eslint-doc-generator/issues/506
* https://github.com/eslint/eslint/issues/17842

This reverts part of:
* https://github.com/platinumazure/eslint-plugin-qunit/pull/416

ESLint no longer allows arbitrary properties like `description` on configs.

Fixes #478.
