### PR TITLE
chore: test on ESLint v9 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
 
     - run: npm ci
     - run: npm run test:unit
+    - run: npm install --save-dev eslint@v9.0.0-beta.0 && npm run test:unit
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2


### PR DESCRIPTION
I would like to make sure eslint-plugin-qunit v8 and v9 are both compatible with ESLint v8 and v9.

* https://github.com/eslint/eslint/releases/tag/v9.0.0-beta.0 