### PR TITLE
Fix eslint v9 compatibility issues

### DIFF
--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -138,8 +138,10 @@ module.exports = {
             },
             Program: function (node) {
                 // Gather all calls to global `equal()`.
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const sourceCode =
                     context.sourceCode ?? context.getSourceCode();
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const scope = sourceCode.getScope
                     ? sourceCode.getScope(node)
                     : context.getScope();

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -138,10 +138,11 @@ module.exports = {
             },
             Program: function (node) {
                 // Gather all calls to global `equal()`.
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode =
+                    context.sourceCode ?? context.getSourceCode();
                 const scope = sourceCode.getScope
-                ? sourceCode.getScope(node)
-                : context.getScope();
+                    ? sourceCode.getScope(node)
+                    : context.getScope();
 
                 const tracker = new ReferenceTracker(scope);
                 const traceMap = { equal: { [ReferenceTracker.CALL]: true } };

--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -136,10 +136,14 @@ module.exports = {
                     testStack.pop();
                 }
             },
-            Program: function () {
+            Program: function (node) {
                 // Gather all calls to global `equal()`.
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const scope = sourceCode.getScope
+                ? sourceCode.getScope(node)
+                : context.getScope();
 
-                const tracker = new ReferenceTracker(context.getScope());
+                const tracker = new ReferenceTracker(scope);
                 const traceMap = { equal: { [ReferenceTracker.CALL]: true } };
 
                 for (const { node } of tracker.iterateGlobalReferences(

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -34,10 +34,11 @@ module.exports = {
     create: function (context) {
         return {
             Program: function (node) {
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode =
+                    context.sourceCode ?? context.getSourceCode();
                 const scope = sourceCode.getScope
-                ? sourceCode.getScope(node)
-                : context.getScope();
+                    ? sourceCode.getScope(node)
+                    : context.getScope();
 
                 const tracker = new ReferenceTracker(scope);
                 const traceMap = {};

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -33,8 +33,13 @@ module.exports = {
 
     create: function (context) {
         return {
-            Program: function () {
-                const tracker = new ReferenceTracker(context.getScope());
+            Program: function (node) {
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const scope = sourceCode.getScope
+                ? sourceCode.getScope(node)
+                : context.getScope();
+
+                const tracker = new ReferenceTracker(scope);
                 const traceMap = {};
                 for (const assertionName of getAssertionNames()) {
                     traceMap[assertionName] = { [ReferenceTracker.CALL]: true };

--- a/lib/rules/no-global-assertions.js
+++ b/lib/rules/no-global-assertions.js
@@ -34,8 +34,10 @@ module.exports = {
     create: function (context) {
         return {
             Program: function (node) {
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const sourceCode =
                     context.sourceCode ?? context.getSourceCode();
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const scope = sourceCode.getScope
                     ? sourceCode.getScope(node)
                     : context.getScope();

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -32,8 +32,10 @@ module.exports = {
     create: function (context) {
         return {
             Program: function (node) {
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const sourceCode =
                     context.sourceCode ?? context.getSourceCode();
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const scope = sourceCode.getScope
                     ? sourceCode.getScope(node)
                     : context.getScope();

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -32,10 +32,11 @@ module.exports = {
     create: function (context) {
         return {
             Program: function (node) {
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode =
+                    context.sourceCode ?? context.getSourceCode();
                 const scope = sourceCode.getScope
-                ? sourceCode.getScope(node)
-                : context.getScope();
+                    ? sourceCode.getScope(node)
+                    : context.getScope();
 
                 const tracker = new ReferenceTracker(scope);
                 const traceMap = { expect: { [ReferenceTracker.CALL]: true } };

--- a/lib/rules/no-global-expect.js
+++ b/lib/rules/no-global-expect.js
@@ -31,8 +31,13 @@ module.exports = {
 
     create: function (context) {
         return {
-            Program: function () {
-                const tracker = new ReferenceTracker(context.getScope());
+            Program: function (node) {
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const scope = sourceCode.getScope
+                ? sourceCode.getScope(node)
+                : context.getScope();
+
+                const tracker = new ReferenceTracker(scope);
                 const traceMap = { expect: { [ReferenceTracker.CALL]: true } };
 
                 for (const { node } of tracker.iterateGlobalReferences(

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -32,8 +32,10 @@ module.exports = {
     create: function (context) {
         return {
             Program: function (node) {
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const sourceCode =
                     context.sourceCode ?? context.getSourceCode();
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const scope = sourceCode.getScope
                     ? sourceCode.getScope(node)
                     : context.getScope();

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -32,10 +32,11 @@ module.exports = {
     create: function (context) {
         return {
             Program: function (node) {
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode =
+                    context.sourceCode ?? context.getSourceCode();
                 const scope = sourceCode.getScope
-                ? sourceCode.getScope(node)
-                : context.getScope();
+                    ? sourceCode.getScope(node)
+                    : context.getScope();
 
                 const tracker = new ReferenceTracker(scope);
                 const traceMap = {

--- a/lib/rules/no-global-module-test.js
+++ b/lib/rules/no-global-module-test.js
@@ -31,8 +31,13 @@ module.exports = {
 
     create: function (context) {
         return {
-            Program: function () {
-                const tracker = new ReferenceTracker(context.getScope());
+            Program: function (node) {
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const scope = sourceCode.getScope
+                ? sourceCode.getScope(node)
+                : context.getScope();
+
+                const tracker = new ReferenceTracker(scope);
                 const traceMap = {
                     asyncTest: { [ReferenceTracker.CALL]: true },
                     module: { [ReferenceTracker.CALL]: true },

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -33,8 +33,13 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            Program: function () {
-                const tracker = new ReferenceTracker(context.getScope());
+            Program: function (node) {
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const scope = sourceCode.getScope
+                ? sourceCode.getScope(node)
+                : context.getScope();
+
+                const tracker = new ReferenceTracker(scope);
                 const traceMap = {
                     start: { [ReferenceTracker.CALL]: true },
                     stop: { [ReferenceTracker.CALL]: true },

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -34,10 +34,11 @@ module.exports = {
 
         return {
             Program: function (node) {
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode =
+                    context.sourceCode ?? context.getSourceCode();
                 const scope = sourceCode.getScope
-                ? sourceCode.getScope(node)
-                : context.getScope();
+                    ? sourceCode.getScope(node)
+                    : context.getScope();
 
                 const tracker = new ReferenceTracker(scope);
                 const traceMap = {

--- a/lib/rules/no-global-stop-start.js
+++ b/lib/rules/no-global-stop-start.js
@@ -34,8 +34,10 @@ module.exports = {
 
         return {
             Program: function (node) {
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const sourceCode =
                     context.sourceCode ?? context.getSourceCode();
+                /* istanbul ignore next: deprecated code paths only followed by old eslint versions */
                 const scope = sourceCode.getScope
                     ? sourceCode.getScope(node)
                     : context.getScope();


### PR DESCRIPTION
Fixes https://github.com/platinumazure/eslint-plugin-qunit/issues/499

I verified all tests pass under eslint v9, but also maintained backward compatibility. Tests require updates that are not v8 compatible so I have another branch where I tested against v9. https://github.com/LucasHill/eslint-plugin-qunit/tree/test_fixes_for_eslint_v9

A future improvement would be to run this plugin against multiple eslint versions, as I can't include the test changes without committing to only testing on v9. If this is desired, I can bring those changes into this branch and the project will be upgraded to test against v9.

I do think it could be worth releasing this in a patch version as the changes are minimal, and intentionally backwards compatible. I know there are plans brewing for the v9 version of this library, but getting folks unblocked now would be awesome! This addon is particularly heavily used in the ember community so I'm trying to push all the eslint plugins in our ecosystem up to v9 compatibility.

Thank you!