### PR TITLE
v8.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## [8.1.2](https://github.com/platinumazure/eslint-plugin-qunit/compare/v8.1.1...v8.1.2) (2024-08-22)
 
+
+### Bug Fixes
+
+* eslint v9 compatibility issues ([#532](https://github.com/platinumazure/eslint-plugin-qunit/issues/532)) ([02b4c8e](https://github.com/platinumazure/eslint-plugin-qunit/commit/02b4c8eac55e04bbb947415e88e61cce124621c9))
 
 ## [8.1.1](https://github.com/platinumazure/eslint-plugin-qunit/compare/v8.1.0...v8.1.1) (2024-02-12)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-qunit",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-qunit",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "license": "MIT",
       "dependencies": {
         "eslint-utils": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-qunit",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "ESLint plugin containing rules useful for QUnit tests.",
   "exports": {
     ".": "./index.js",


### PR DESCRIPTION
This PR includes manual version/changelog updates since I'm having trouble with our `npm run release` command.

After this PR is merged, we should create a [new GitHub Release](https://github.com/platinumazure/eslint-plugin-qunit/releases/new) with the included changelog and using the 8.1.2 version tag from this PR.

I have already manually released the version to npm: https://www.npmjs.com/package/eslint-plugin-qunit/v/8.1.2

This version includes:
* #532