### PR TITLE
fix: false positive in `literal-compare-order` rule

### DIFF
--- a/lib/rules/literal-compare-order.js
+++ b/lib/rules/literal-compare-order.js
@@ -115,13 +115,11 @@ module.exports = {
             }
 
             /* istanbul ignore else: correctly does nothing */
-            if (
-                !assertVar ||
-                utils.isComparativeAssertion(node.callee, assertVar)
-            ) {
-                const compareActualFirst =
-                    !assertVar ||
-                    utils.shouldCompareActualFirst(node.callee, assertVar);
+            if (utils.isComparativeAssertion(node.callee, assertVar)) {
+                const compareActualFirst = utils.shouldCompareActualFirst(
+                    node.callee,
+                    assertVar,
+                );
                 checkLiteralCompareOrder(node.arguments, compareActualFirst);
             }
         }
@@ -137,10 +135,7 @@ module.exports = {
                     });
                 } else if (testStack.length > 0) {
                     const assertVar = getAssertContext();
-                    if (
-                        !assertVar ||
-                        utils.isAssertion(node.callee, assertVar)
-                    ) {
+                    if (utils.isAssertion(node.callee, assertVar)) {
                         processAssertion(node, assertVar);
                     }
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ exports.getAssertionNames = getAssertionNames;
 
 /**
  * @param {import('estree').Node} calleeNode
- * @param {string} assertVar
+ * @param {string | null} assertVar
  * @returns {{allowedArities: number[], compareActualFirst?: boolean} | null}
  */
 function getAssertionMetadata(calleeNode, assertVar) {
@@ -345,7 +345,7 @@ exports.getAssertContextName = function (functionExpr) {
 
 /**
  * @param {import('estree').Node} calleeNode
- * @param {string} assertVar
+ * @param {string | null} assertVar
  * @returns {boolean}
  */
 exports.isAssertion = function (calleeNode, assertVar) {
@@ -368,7 +368,7 @@ exports.getAllowedArities = function (calleeNode, assertVar) {
 
 /**
  * @param {import('estree').Node} calleeNode
- * @param {string} assertVar
+ * @param {string | null} assertVar
  * @returns {boolean}
  */
 exports.isComparativeAssertion = function (calleeNode, assertVar) {
@@ -379,7 +379,7 @@ exports.isComparativeAssertion = function (calleeNode, assertVar) {
 
 /**
  * @param {import('estree').Node} calleeNode
- * @param {string} assertVar
+ * @param {string | null} assertVar
  * @returns {boolean}
  */
 exports.shouldCompareActualFirst = function (calleeNode, assertVar) {

--- a/tests/lib/rules/literal-compare-order.js
+++ b/tests/lib/rules/literal-compare-order.js
@@ -86,6 +86,8 @@ ruleTester.run("literal-compare-order", rule, {
 
         // avoid crash in BDD-style assertions
         "QUnit.test('Name', function() { expect(variable).to.equal('Literal'); });",
+
+        "QUnit.test('Name', function() { router.on('routerDidChange', () => {}); });",
     ],
     invalid: [
         // equal


### PR DESCRIPTION
Fixes #589.

Caused by this PR because there was some ambiguity over whether an assert variable should be required by some of the utils. This fix reverts the code to the previous behavior and adds a test case.
- https://github.com/qunitjs/eslint-plugin-qunit/pull/571