### PR TITLE
fix: Rules do now also work for module hooks "after" and "before"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,12 @@ const assert = require("node:assert");
 const SUPPORTED_TEST_IDENTIFIERS = new Set(["test", "asyncTest", "only"]);
 
 const OLD_MODULE_HOOK_IDENTIFIERS = ["setup", "teardown"];
-const NEW_MODULE_HOOK_IDENTIFIERS = ["beforeEach", "afterEach"];
+const NEW_MODULE_HOOK_IDENTIFIERS = [
+    "before",
+    "beforeEach",
+    "afterEach",
+    "after",
+];
 const ALL_MODULE_HOOK_IDENTIFIERS = new Set([
     ...OLD_MODULE_HOOK_IDENTIFIERS,
     ...NEW_MODULE_HOOK_IDENTIFIERS,

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -189,6 +189,26 @@ ruleTester.run("no-arrow-tests", rule, {
             ],
         },
         {
+            code: "QUnit.module('module', { before: () => {} });",
+            output: "QUnit.module('module', { before: function() {} });",
+            errors: [
+                {
+                    messageId: "noArrowFunction",
+                    type: "ArrowFunctionExpression",
+                },
+            ],
+        },
+        {
+            code: "QUnit.module('module', { after: () => {} });",
+            output: "QUnit.module('module', { after: function() {} });",
+            errors: [
+                {
+                    messageId: "noArrowFunction",
+                    type: "ArrowFunctionExpression",
+                },
+            ],
+        },
+        {
             code: "module('module', { setup: () => {} });",
             output: "module('module', { setup: function() {} });",
             errors: [

--- a/tests/lib/rules/no-qunit-start-in-tests.js
+++ b/tests/lib/rules/no-qunit-start-in-tests.js
@@ -58,6 +58,14 @@ ruleTester.run("no-qunit-start-in-tests", rule, {
             errors: [createError("afterEach hook")],
         },
         {
+            code: 'QUnit.module("module", { before: function() { QUnit.start(); } });',
+            errors: [createError("before hook")],
+        },
+        {
+            code: 'QUnit.module("module", { after: function() { QUnit.start(); } });',
+            errors: [createError("after hook")],
+        },
+        {
             code: 'QUnit.module("module", { setup: function() { QUnit.start(); } });',
             errors: [createError("setup hook")],
         },

--- a/tests/lib/rules/no-setup-teardown.js
+++ b/tests/lib/rules/no-setup-teardown.js
@@ -29,8 +29,14 @@ ruleTester.run("no-setup-teardown", rule, {
         // afterEach
         "QUnit.module('Module', { afterEach: function () {} });",
 
-        // both
-        "QUnit.module('Module', { beforeEach: function () {}, afterEach: function () {} });",
+        // before
+        "QUnit.module('Module', { before: function () {} });",
+
+        // after
+        "QUnit.module('Module', { after: function () {} });",
+
+        // all
+        "QUnit.module('Module', { before: function () {}, beforeEach: function () {}, afterEach: function () {}, after: function () {} });",
 
         // other property names are not reported
         "QUnit.module('Module', { foo: function () {} });",

--- a/tests/lib/rules/resolve-async.js
+++ b/tests/lib/rules/resolve-async.js
@@ -196,11 +196,19 @@ ruleTester.run("resolve-async", rule, {
             errors: [createNeedStartCallsMessage("Property")],
         },
         {
+            code: "QUnit.module('name', { before: function () { QUnit.stop(); } });",
+            errors: [createNeedStartCallsMessage("Property")],
+        },
+        {
             code: "QUnit.module('name', { beforeEach: function () { QUnit.stop(); } });",
             errors: [createNeedStartCallsMessage("Property")],
         },
         {
             code: "QUnit.module('name', { afterEach: function () { QUnit.stop(); } });",
+            errors: [createNeedStartCallsMessage("Property")],
+        },
+        {
+            code: "QUnit.module('name', { after: function () { QUnit.stop(); } });",
             errors: [createNeedStartCallsMessage("Property")],
         },
 


### PR DESCRIPTION
Fix for rules not applying to `before` and `after` module hooks