### PR TITLE
chore: remove requireindex dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@
 
 "use strict";
 
-const requireIndex = require("requireindex");
 const path = require("node:path");
 
 const pathParts = __dirname.split(path.sep);
@@ -24,7 +23,47 @@ module.exports = {
         version: pkg.version,
     },
 
-    rules: requireIndex(`${__dirname}/lib/rules`),
+    rules: {
+        "assert-args": require("./lib/rules/assert-args"),
+        "literal-compare-order": require("./lib/rules/literal-compare-order"),
+        "no-arrow-tests": require("./lib/rules/no-arrow-tests"),
+        "no-assert-equal": require("./lib/rules/no-assert-equal"),
+        "no-assert-equal-boolean": require("./lib/rules/no-assert-equal-boolean"),
+        "no-assert-logical-expression": require("./lib/rules/no-assert-logical-expression"),
+        "no-assert-ok": require("./lib/rules/no-assert-ok"),
+        "no-async-in-loops": require("./lib/rules/no-async-in-loops"),
+        "no-async-module-callbacks": require("./lib/rules/no-async-module-callbacks"),
+        "no-async-test": require("./lib/rules/no-async-test"),
+        "no-commented-tests": require("./lib/rules/no-commented-tests"),
+        "no-compare-relation-boolean": require("./lib/rules/no-compare-relation-boolean"),
+        "no-conditional-assertions": require("./lib/rules/no-conditional-assertions"),
+        "no-early-return": require("./lib/rules/no-early-return"),
+        "no-global-assertions": require("./lib/rules/no-global-assertions"),
+        "no-global-expect": require("./lib/rules/no-global-expect"),
+        "no-global-module-test": require("./lib/rules/no-global-module-test"),
+        "no-global-stop-start": require("./lib/rules/no-global-stop-start"),
+        "no-hooks-from-ancestor-modules": require("./lib/rules/no-hooks-from-ancestor-modules"),
+        "no-identical-names": require("./lib/rules/no-identical-names"),
+        "no-init": require("./lib/rules/no-init"),
+        "no-jsdump": require("./lib/rules/no-jsdump"),
+        "no-loose-assertions": require("./lib/rules/no-loose-assertions"),
+        "no-negated-ok": require("./lib/rules/no-negated-ok"),
+        "no-nested-tests": require("./lib/rules/no-nested-tests"),
+        "no-ok-equality": require("./lib/rules/no-ok-equality"),
+        "no-only": require("./lib/rules/no-only"),
+        "no-qunit-push": require("./lib/rules/no-qunit-push"),
+        "no-qunit-start-in-tests": require("./lib/rules/no-qunit-start-in-tests"),
+        "no-qunit-stop": require("./lib/rules/no-qunit-stop"),
+        "no-reassign-log-callbacks": require("./lib/rules/no-reassign-log-callbacks"),
+        "no-reset": require("./lib/rules/no-reset"),
+        "no-setup-teardown": require("./lib/rules/no-setup-teardown"),
+        "no-skip": require("./lib/rules/no-skip"),
+        "no-test-expect-argument": require("./lib/rules/no-test-expect-argument"),
+        "no-throws-string": require("./lib/rules/no-throws-string"),
+        "require-expect": require("./lib/rules/require-expect"),
+        "require-object-in-propequal": require("./lib/rules/require-object-in-propequal"),
+        "resolve-async": require("./lib/rules/resolve-async"),
+    },
 
     // eslint-disable-next-line sort-keys
     configs: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
     "": {
       "name": "eslint-plugin-qunit",
       "version": "8.2.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "requireindex": "^1.2.0"
+        "@eslint-community/eslint-utils": "^4.4.0"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -25,7 +25,6 @@
         "@types/estree": "^1.0.8",
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.3",
-        "@types/requireindex": "^1.2.4",
         "@typescript-eslint/parser": "^8.54.0",
         "all-contributors-cli": "^6.26.1",
         "chai": "^4.3.10",
@@ -1799,13 +1798,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/requireindex": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/requireindex/-/requireindex-1.2.4.tgz",
-      "integrity": "sha512-9NwqEWtA606+W8sSNMAzmyTzgHOKBIDKtsHl16ctbtoJdkyps/zIGefBJmfHYkKLgAH8Ptfy0TJIlXVn+JM2Lw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9668,14 +9660,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "node_modules/requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "engines": {
-        "node": ">=0.10.5"
-      }
     },
     "node_modules/resolve": {
       "version": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@eslint-community/eslint-utils": "^4.4.0",
-    "requireindex": "^1.2.0"
+    "@eslint-community/eslint-utils": "^4.4.0"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -42,7 +41,6 @@
     "@types/estree": "^1.0.8",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
-    "@types/requireindex": "^1.2.4",
     "@typescript-eslint/parser": "^8.54.0",
     "all-contributors-cli": "^6.26.1",
     "chai": "^4.3.10",

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,7 +12,6 @@ const assert = require("chai").assert,
     { rules, configs } = require("../index"),
     fs = require("node:fs"),
     path = require("node:path"),
-    requireIndex = require("requireindex"),
     plugin = require("../index.js"),
     recommendedFlatConfig = require("../lib/configs/recommended.js");
 
@@ -24,8 +23,23 @@ const ruleNames = fs
     .readdirSync("./lib/rules")
     .map((rawFileName) => path.basename(rawFileName, ".js"));
 
+const configDir = path.join(__dirname, "../lib/configs");
+const flatConfigs = Object.fromEntries(
+    fs
+        .readdirSync(configDir)
+        .filter((fileName) => fileName.endsWith(".js"))
+        .map((fileName) => [
+            path.basename(fileName, ".js"),
+            require(path.join(configDir, fileName)),
+        ]),
+);
+
 describe("index.js", function () {
     describe("rules", function () {
+        it("should export every rule file on disk and no extras", function () {
+            assert.strictEqual(Object.keys(rules).length, ruleNames.length);
+        });
+
         for (const ruleName of ruleNames) {
             describe(ruleName, function () {
                 it("should appear in rule exports", function () {
@@ -88,11 +102,10 @@ describe("index.js", function () {
         });
 
         describe("flat", function () {
-            describe("load all flat configs via requireIndex", function () {
+            describe("load all flat configs", function () {
                 // eslint-disable-next-line mocha/no-setup-in-describe -- rule doesn't like function calls like `Object.entries()`
                 for (const [configName, config] of Object.entries(
-                    // eslint-disable-next-line mocha/no-setup-in-describe -- rule doesn't like function calls like `Object.entries()`
-                    requireIndex(`${__dirname}/../lib/configs`),
+                    flatConfigs,
                 )) {
                     describe(configName, function () {
                         it("has the right plugins", function () {


### PR DESCRIPTION
## Summary

`requireindex` is one of only two runtime dependencies. Directory scanning at load time defeats bundlers/single-file builds and is part of why the dist-vs-source path juggling exists. Replacing it with a static rule map is behavior-identical and keeps this change in semver-minor/patch territory.

- Replace `requireIndex(...)` with an explicit, sorted rule map in `index.js` (39 rules).
- Load flat configs in `tests/index.js` via `fs.readdirSync` and assert exported rule count matches files on disk.
- Drop `requireindex` and `@types/requireindex`.

## Related PRs

Part of a modernization split (each independent off `main`):

- **This PR**: remove requireindex
- #684: nyc → c8
- #685: npm-run-all → npm-run-all2
- #686–#690: CI hardening

## Test plan

- [ ] `npm run build && npm test`
- [ ] `node -e "console.log(Object.keys(require('./dist/index.js').rules).length)"` → 39