### PR TITLE
ci: run push workflow only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## Summary

`on.push` with no branch filter plus `pull_request` runs the full matrix twice on every PR branch push. Scoping push to `main` removes the duplicate without changing PR or main coverage.

- Limit `on.push` to `branches: [main]`.
- Keep `pull_request` targeting `main`.

## Related PRs

CI hardening split (each independent):

- **This PR**: push only on main
- #687: concurrency / cancel-in-progress
- #688: `contents: read`
- #689: npm cache + Node matrix + ESLint 10 gate
- #690: ESLint 8.38 peer smoke

## Test plan

- [ ] Opening/updating a PR still triggers CI once
- [ ] Pushing to `main` still triggers CI