### PR TITLE
ci: cancel in-progress runs for the same ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@
 
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
## Summary

Without a concurrency group, rapid pushes leave overlapping workflow runs burning CI minutes. Cancel-in-progress keeps only the latest run for a given ref.

- Add `concurrency` with `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true`.

## Related PRs

- #686: push only on main
- **This PR**: concurrency / cancel-in-progress
- #688: `contents: read`
- #689: npm cache + Node matrix + ESLint 10 gate
- #690: ESLint 8.38 peer smoke

## Test plan

- [ ] Push twice quickly to a PR branch; the first run is cancelled