### PR TITLE
ci: set top-level contents: read permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
## Summary

Workflows should declare least-privilege token scopes explicitly. Top-level `contents: read` is enough for checkout and Coveralls (which uses the provided `GITHUB_TOKEN`); widen per-job only if something fails.

- Add top-level `permissions: contents: read`.

## Related PRs

- #686: push only on main
- #687: concurrency / cancel-in-progress
- **This PR**: `contents: read`
- #689: npm cache + Node matrix + ESLint 10 gate
- #690: ESLint 8.38 peer smoke

## Test plan

- [ ] CI jobs complete successfully
- [ ] Coveralls parallel upload still succeeds