### PR TITLE
ci: cache npm and expand the Node version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        # TODO: We still support Node 16 but can't run ESLint v9 tests with it anymore.
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v5
@@ -26,12 +25,13 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        cache: npm
 
     - run: npm ci
     - run: npm run test:unit
 
     - name: Test with ESLint v10
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '22.x'
       run: npm install --save-dev eslint@10 && npm run test:unit
 
     - name: Coveralls
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20.x"
+          cache: npm
       - run: npm ci
       - run: npm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
+        # TODO: We still support Node 16 but can't run ESLint v9 tests with it anymore.
         node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:


### PR DESCRIPTION
## Summary

`engines` allow `>=20.0.0`, but CI only tested 18.x and 20.x — nothing above 20. Expanding to 22.x/24.x catches regressions on current LTS/current lines. `cache: npm` speeds installs; the ESLint 10 bracket job moves to a modern matrix cell (22.x) so it stays a single top-of-peer guard as the matrix grows.

- Enable `cache: npm` on all `actions/setup-node` steps.
- Expand the Node matrix to `[18.x, 20.x, 22.x, 24.x]`.
- Gate the ESLint v10 unit-test step to Node `22.x` (was `20.x`).

## Related PRs

- #686: push only on main
- #687: concurrency / cancel-in-progress
- #688: `contents: read`
- **This PR**: npm cache + Node matrix + ESLint 10 gate
- #690: ESLint 8.38 peer smoke (bottom of peer range)

## Test plan

- [ ] Matrix jobs green on 18/20/22/24 (ubuntu + windows)
- [ ] npm cache hits on subsequent runs
- [ ] ESLint 10 step runs only on the 22.x matrix rows