### PR TITLE
ci: smoke-test the ESLint 8.38 peer minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  # Flat-config RuleTester languageOptions break under ESLint 8, so exercise the
+  # declared peer minimum with a legacy eslintrc-style smoke instead of mocha.
+  min-peer-eslint8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20.x"
+      - run: npm ci
+      - run: npm run build
+      - run: npm install --no-save --force eslint@8.38.0
+      - run: node scripts/smoke-eslint8.js
+
   finish-coveralls:
     needs: build
     runs-on: ubuntu-latest

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -204,6 +204,6 @@ module.exports = [
         },
     },
     {
-        ignores: ["dist/**/*"],
+        ignores: ["dist/**/*", "scripts/**/*"],
     },
 ];

--- a/scripts/smoke-eslint8.js
+++ b/scripts/smoke-eslint8.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Smoke-test eslint-plugin-qunit under the ESLint 8.38 peer minimum.
+ *
+ * The mocha RuleTester suite uses flat-config `languageOptions`, which ESLint 8
+ * rejects, so CI exercises the legacy `plugins: ["qunit"]` config instead.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { ESLint } = require("eslint");
+
+const fixture = `
+QUnit.module("mod", function () {
+    QUnit.only("test", function (assert) {
+        assert.ok(true);
+    });
+});
+`;
+
+async function main() {
+    const eslint = new ESLint({
+        useEslintrc: false,
+        cwd: path.join(__dirname, ".."),
+        resolvePluginsRelativeTo: path.join(__dirname, ".."),
+        overrideConfig: {
+            plugins: ["qunit"],
+            rules: {
+                "qunit/no-only": "error",
+            },
+        },
+    });
+
+    const [result] = await eslint.lintText(fixture, {
+        filePath: "smoke-eslint8-fixture.js",
+    });
+
+    assert.ok(result, "expected a lint result");
+    assert.ok(
+        result.messages.some(
+            (message) =>
+                message.ruleId === "qunit/no-only" && message.severity === 2,
+        ),
+        `expected qunit/no-only to fire, got: ${JSON.stringify(result.messages, null, 2)}`,
+    );
+
+    // eslint-disable-next-line no-console -- smoke script progress
+    console.log("eslint@8.38 smoke passed (qunit/no-only)");
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

The ESLint v10 CI step guards the top of the peer range; nothing guarded the declared floor (`eslint >=8.38.0`). The mocha suite cannot run there — many rule tests use flat-config `languageOptions`, which ESLint 8's RuleTester rejects — so this adds a legacy `plugins: ["qunit"]` smoke that asserts a known rule fires.

- Add `min-peer-eslint8`: `npm ci`, build, `npm install --no-save --force eslint@8.38.0`, then `scripts/smoke-eslint8.js`.
- Ignore `scripts/**` in ESLint config (already excluded from coverage).

## Related PRs

- #686: push only on main
- #687: concurrency / cancel-in-progress
- #688: `contents: read`
- #689: npm cache + Node matrix + ESLint 10 gate (top of peer range)
- **This PR**: ESLint 8.38 peer smoke (bottom of peer range)

## Test plan

- [ ] `min-peer-eslint8` job is green
- [ ] Existing matrix / lint / Coveralls jobs still green