### PR TITLE
chore: export ./package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,15 @@
   "version": "8.2.6",
   "description": "ESLint plugin containing rules useful for QUnit tests.",
   "exports": {
-    ".": "./dist/index.js",
-    "./configs/*": "./dist/lib/configs/*.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./configs/*": {
+      "types": "./dist/lib/configs/*.d.ts",
+      "default": "./dist/lib/configs/*.js"
+    },
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,8 @@
   "version": "8.2.6",
   "description": "ESLint plugin containing rules useful for QUnit tests.",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./configs/*": {
-      "types": "./dist/lib/configs/*.d.ts",
-      "default": "./dist/lib/configs/*.js"
-    },
+    ".": "./dist/index.js",
+    "./configs/*": "./dist/lib/configs/*.js",
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

\`require('eslint-plugin-qunit/package.json')\` currently throws \`ERR_PACKAGE_PATH_NOT_EXPORTED\` because the exports map does not list that subpath. Exporting it is a common ecosystem convention (tools that resolve a plugin’s metadata by package name) and unblocks a follow-up that replaces the \`index.js\` dist-vs-source \`require(\"../package.json\")\` hack with a self-reference.

**Not included:** explicit \`types\` conditions on \`.\` / \`./configs/*\`. Those are unnecessary today — TypeScript already finds sibling \`.d.ts\` files next to the \`exports\` JS targets (\`attw\` green; \`moduleResolution: node16\` scratch consumer type-checks both entrypoints via sibling inference).

- Add \`\"./package.json\": \"./package.json\"\` to \`exports\`
- Leave existing \`.\` and \`./configs/*\` string targets unchanged
- Keep top-level \`main\` / \`types\`

## Test plan

- [x] \`require('eslint-plugin-qunit/package.json')\` succeeds via the package name
- [ ] \`npm run build && npm pack\`