### PR TITLE
chore: load package.json via package exports self-reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,15 +7,7 @@
 
 "use strict";
 
-const path = require("node:path");
-
-const pathParts = __dirname.split(path.sep);
-const pkg =
-    pathParts[pathParts.length - 1] === "dist"
-        ? // @ts-expect-error -- TODO: ESM/TypeScript conversion should fix this.
-          require("../package.json") // eslint-disable-line n/no-missing-require -- this is the path when this file is compiled to dist/
-        : // @ts-expect-error -- TODO: ESM/TypeScript conversion should fix this.
-          require("./package.json");
+const pkg = require("eslint-plugin-qunit/package.json");
 
 module.exports = {
     meta: {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "exclude": [
     "tests/**",
-    "eslint.config.js",
-    "types/**"
+    "eslint.config.js"
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": [
     "tests/**",
-    "eslint.config.js"
+    "eslint.config.js",
+    "types/**"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
 
     /* Modules */
     "module": "nodenext",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -114,6 +114,7 @@
   "include": [
     "*.js",
     "tests/**/*",
-    "lib/**/*"
+    "lib/**/*",
+    "types/**/*.d.ts"
   ]
 }

--- a/types/eslint-plugin-qunit-package-json.d.ts
+++ b/types/eslint-plugin-qunit-package-json.d.ts
@@ -1,0 +1,7 @@
+declare module "eslint-plugin-qunit/package.json" {
+    const pkg: {
+        name: string;
+        version: string;
+    };
+    export = pkg;
+}


### PR DESCRIPTION
## Summary

Replace the `pathParts` dual-require hack in `index.js` (dist vs source `package.json` paths + two `@ts-expect-error`s) with `require("eslint-plugin-qunit/package.json")`, now that `#691` exports `./package.json`.

Ambient `declare module` types are used instead of `resolveJsonModule`, so tsc does not copy `package.json` into `dist/` (which would create a nested package scope). `rootDir` is set explicitly because resolving the package via its export map requires it.

Part of the TypeScript conversion plan for #596 (PR 1 of the series).

## Test plan

- [x] `npm run build` — `dist/index.js` uses the package-name require
- [x] `npm run lint:types`
- [x] `npm test` (1354 passing)
- [x] `require('./dist/index.js').meta` → `{ name, version }`

## Related PRs

- **This PR**: package.json self-reference (ready now)
- Next (independent): test/lint infra for TS (`tsx`, extension-agnostic `tests/index.js`, drop `erasableSyntaxOnly`)
- Later (depends on infra): `lib/utils.ts` + rule conversion batches


Made with [Cursor](https://cursor.com)